### PR TITLE
Correct representation values for 2 loops on edges in heu net

### DIFF
--- a/pm4py/objects/heuristics_net/net.py
+++ b/pm4py/objects/heuristics_net/net.py
@@ -212,9 +212,8 @@ class HeuristicsNet:
                         v_n1_n2 = self.dfg_matrix[n1][n2] if n1 in self.dfg_matrix and n2 in self.dfg_matrix[n1] else 0
                         v_n2_n1 = self.dfg_matrix[n2][n1] if n2 in self.dfg_matrix and n1 in self.dfg_matrix[n2] else 0
 
-                        repr_value = self.performance_matrix[n1][n2] if n1 in self.performance_matrix and n2 in self.performance_matrix[n1] else 0
-
                         if (n1, n2) not in added_loops:
+                            repr_value = self.performance_matrix[n1][n2] if n1 in self.performance_matrix and n2 in self.performance_matrix[n1] else 0
                             added_loops.add((n1, n2))
                             self.nodes[n1].add_output_connection(self.nodes[n2], 0,
                                                                  v_n1_n2, repr_value=repr_value)
@@ -222,6 +221,7 @@ class HeuristicsNet:
                                                                 v_n2_n1, repr_value=repr_value)
 
                         if (n2, n1) not in added_loops:
+                            repr_value = self.performance_matrix[n2][n1] if n2 in self.performance_matrix and n1 in self.performance_matrix[n2] else 0
                             added_loops.add((n2, n1))
                             self.nodes[n2].add_output_connection(self.nodes[n1], 0,
                                                                  v_n2_n1, repr_value=repr_value)


### PR DESCRIPTION
There was a bug in the representation of heu_nets. 2-Loops always got the same representation values on the edges in both directions.