### PR TITLE
Alpha miner - Feedback and Multiprocessing Patch

### DIFF
--- a/pm4py/algo/discovery/alpha/data_structures/alpha_classic_abstraction.py
+++ b/pm4py/algo/discovery/alpha/data_structures/alpha_classic_abstraction.py
@@ -14,8 +14,10 @@ class ClassicAlphaAbstraction:
         self.__start_activities = start_activities
         self.__end_activities = end_activities
         self.__dfg = dfg
-        self.__causal_relations = {k: v for k, v in causal_algorithm.apply(self.dfg, variant=CAUSAL_ALPHA).items() if
-                                   v > 0}.keys()
+        self.__causal_relations = [
+            k for k, v in causal_algorithm.apply(self.dfg, variant=CAUSAL_ALPHA).items() if
+            v > 0
+            ]
         self.__parallel = {(f, t) for (f, t) in self.dfg if (t, f) in self.dfg}
 
     def __get_causal_relation(self):

--- a/pm4py/algo/discovery/alpha/versions/classic.py
+++ b/pm4py/algo/discovery/alpha/versions/classic.py
@@ -27,7 +27,6 @@ from pm4py.algo.discovery.parameters import Parameters
 from pm4py.util import exec_utils
 
 from pm4py.algo.discovery.alpha.versions.classic_support import run_batch_alpha_pairs
-from multiprocessing import Pool
 from os import cpu_count
 
 from tqdm.auto import tqdm

--- a/pm4py/algo/discovery/alpha/versions/classic.py
+++ b/pm4py/algo/discovery/alpha/versions/classic.py
@@ -275,8 +275,28 @@ def __pair_maximizer(alpha_pairs, pair):
     return True
 
 
-def __check_is_unrelated(parallel_relation, causal_relation, item_set_1, item_set_2):
-    for pair in product(item_set_1, item_set_2):
+def __check_is_unrelated(parallel_relation, causal_relation, 
+                                        item_set_1, item_set_2,
+                                        parallel_relation_starts, causal_relation_starts,
+                                        parallel_relation_ends, causal_relation_ends):
+
+    reduced_item_set_1 = [
+        item 
+        for item 
+        in item_set_1
+        if item in parallel_relation_starts
+        or item in causal_relation_starts
+    ]
+
+    reduced_item_set_2 = [
+        item 
+        for item 
+        in item_set_2
+        if item in parallel_relation_ends
+        or item in causal_relation_ends
+    ]
+
+    for pair in product(reduced_item_set_1, reduced_item_set_2):
         if pair in parallel_relation or pair in causal_relation:
             return True
     return False

--- a/pm4py/algo/discovery/alpha/versions/classic_support.py
+++ b/pm4py/algo/discovery/alpha/versions/classic_support.py
@@ -1,0 +1,28 @@
+import pm4py.algo.discovery.alpha.versions.classic as alpha_classic
+
+def find_alpha_pair(
+    left_pair:tuple,
+    right_pair:tuple,
+    parallel_relation:list,
+    causal_relation:list,
+    alpha_parallel_relation_starts:list,
+    alpha_causal_relation_starts:list,
+    alpha_parallel_relation_ends:list,
+    alpha_causal_relation_ends:list
+    ) -> tuple:
+
+    if left_pair[0].issubset(right_pair[0]) or left_pair[1].issubset(right_pair[1]):
+                    if not (
+                            alpha_classic.__check_is_unrelated(
+                        parallel_relation, causal_relation,
+                        left_pair[0], right_pair[0],
+                        alpha_parallel_relation_starts,alpha_causal_relation_starts,
+                        alpha_parallel_relation_ends,alpha_causal_relation_ends) 
+                        or
+                              alpha_classic.__check_is_unrelated(
+                        parallel_relation, causal_relation,
+                        left_pair[1], right_pair[1],
+                        alpha_parallel_relation_starts,alpha_causal_relation_starts,
+                        alpha_parallel_relation_ends,alpha_causal_relation_ends)
+                        ):
+                            return (left_pair[0] | right_pair[0], left_pair[1] | right_pair[1])

--- a/pm4py/algo/discovery/alpha/versions/classic_support.py
+++ b/pm4py/algo/discovery/alpha/versions/classic_support.py
@@ -1,28 +1,111 @@
 import pm4py.algo.discovery.alpha.versions.classic as alpha_classic
 
+from typing import TypeVar
+from multiprocessing import Pool
+from os import cpu_count
+from math import ceil
+
+ClassicAlphaAbstraction = TypeVar('ClassicAlphaAbstraction')
+
 def find_alpha_pair(
     left_pair:tuple,
-    right_pair:tuple,
+    right_pairs:list,
     parallel_relation:list,
     causal_relation:list,
     alpha_parallel_relation_starts:list,
     alpha_causal_relation_starts:list,
     alpha_parallel_relation_ends:list,
     alpha_causal_relation_ends:list
-    ) -> tuple:
+    ) -> list:
 
-    if left_pair[0].issubset(right_pair[0]) or left_pair[1].issubset(right_pair[1]):
-                    if not (
-                            alpha_classic.__check_is_unrelated(
-                        parallel_relation, causal_relation,
-                        left_pair[0], right_pair[0],
-                        alpha_parallel_relation_starts,alpha_causal_relation_starts,
-                        alpha_parallel_relation_ends,alpha_causal_relation_ends) 
-                        or
-                              alpha_classic.__check_is_unrelated(
-                        parallel_relation, causal_relation,
-                        left_pair[1], right_pair[1],
+    new_rights = []
+    for right_pair in right_pairs:
+        if left_pair[0].issubset(right_pair[0]) or left_pair[1].issubset(right_pair[1]):
+                        if not (
+                                alpha_classic.__check_is_unrelated(
+                            parallel_relation, causal_relation,
+                            left_pair[0], right_pair[0],
+                            alpha_parallel_relation_starts,alpha_causal_relation_starts,
+                            alpha_parallel_relation_ends,alpha_causal_relation_ends) 
+                            or
+                                alpha_classic.__check_is_unrelated(
+                            parallel_relation, causal_relation,
+                            left_pair[1], right_pair[1],
+                            alpha_parallel_relation_starts,alpha_causal_relation_starts,
+                            alpha_parallel_relation_ends,alpha_causal_relation_ends)
+                            ):
+                                new_rights.append(
+                                     (left_pair[0] | right_pair[0], left_pair[1] | right_pair[1])
+                                )
+    return new_rights
+
+def run_batch_alpha_pairs(
+    t1:tuple,
+    pairs:list,
+    alpha_abstraction:ClassicAlphaAbstraction,
+    ) -> list :
+        # make starts and ends for relations
+        alpha_parallel_relation_starts = [
+        start 
+        for start,end
+        in alpha_abstraction.parallel_relation
+        ]
+        alpha_parallel_relation_ends = [
+            end 
+            for start,end
+            in alpha_abstraction.parallel_relation
+        ]
+        alpha_causal_relation_starts = [
+            start 
+            for start,end
+            in alpha_abstraction.causal_relation
+        ]
+        alpha_causal_relation_ends = [
+            end 
+            for start,end
+            in alpha_abstraction.causal_relation
+        ]
+        #setup workers and begin processing
+        with Pool(processes=cpu_count()-1) as p:
+                #create new potential rights
+                new_rights =  [ t2 
+                            for t2 in pairs 
+                            if t2 != None
+                            if (t1[0] | t2[0], t1[1] | t2[1]) not in pairs
+                            and t1 != t2 
+                        ]
+                #batch new rights for workers
+                batch_size = ceil(len(new_rights)/(cpu_count()-1))
+                new_rights = [
+                    new_rights[start:end]
+                    for start,end
+                    in zip(
+                        range(0,len(new_rights)+batch_size,batch_size),
+                        range(50,len(new_rights)+batch_size*2,batch_size)
+                    )
+                ]
+                #put workers to work on finding alpha pairs
+                new_pairs = p.starmap(
+                    find_alpha_pair,
+                    [
+                        (t1,t2,
+                        alpha_abstraction.parallel_relation,alpha_abstraction.causal_relation,
                         alpha_parallel_relation_starts,alpha_causal_relation_starts,
                         alpha_parallel_relation_ends,alpha_causal_relation_ends)
-                        ):
-                            return (left_pair[0] | right_pair[0], left_pair[1] | right_pair[1])
+                        for t2 
+                        in new_rights
+                    ]
+                )
+                #unpack results from workers
+                new_pairs = [
+                    pair 
+                    for result 
+                    in new_pairs
+                    for pair 
+                    in result
+                ]
+        #add unseen alpha pairs to pairs
+        for new_pair in new_pairs:
+            if new_pair not in pairs and new_pair != None:
+                pairs.append(new_pair)
+        return pairs

--- a/pm4py/algo/discovery/alpha/versions/classic_support.py
+++ b/pm4py/algo/discovery/alpha/versions/classic_support.py
@@ -1,24 +1,51 @@
 import pm4py.algo.discovery.alpha.versions.classic as alpha_classic
 
-from typing import TypeVar
+from typing import TypeVar,List
 from multiprocessing import Pool
 from os import cpu_count
 from math import ceil
 
 ClassicAlphaAbstraction = TypeVar('ClassicAlphaAbstraction')
+Key = TypeVar('Key')
+Value = TypeVar('Value')
 
 def find_alpha_pair(
     left_pair:tuple,
-    right_pairs:list,
-    parallel_relation:list,
-    causal_relation:list,
-    alpha_parallel_relation_starts:list,
-    alpha_causal_relation_starts:list,
-    alpha_parallel_relation_ends:list,
-    alpha_causal_relation_ends:list
-    ) -> list:
+    right_pairs:List[tuple],
+    parallel_relation:List[tuple],
+    causal_relation:List[tuple],
+    alpha_parallel_relation_starts:List[Key],
+    alpha_causal_relation_starts:List[Key],
+    alpha_parallel_relation_ends:List[Value],
+    alpha_causal_relation_ends:List[Value]
+    ) -> List[tuple]:
+    """
+    find_alpha_pair
+    ----------------
+    Creates alpha pairs for the Alpha Miner (classic) based on the give relations,
+    left side and a collection of possible right pairs
 
-    new_rights = []
+    Parameters
+    ------------
+    left_pair\n
+        \tConsidered left pair (tuple)\n
+    right_pairs\n
+        \tPossible joins for left_pair (list of tuples)\n
+    parallel_relation\n
+        \tList of tuples from ClassicAlphaAbstraction.parallel_relation\n
+    causal_relation\n
+        \tList of tuples from ClassicAlphaAbstraction.causal_relation\n
+    alpha_parallel_relation_[starts([0])/ends([1])]\n
+        \tList of key/values from ClassicAlphaAbstraction.parallel_relation\n
+    alpha_causal_relation_[starts([0])/ends([1])]\n
+        \tList of key/values from ClassicAlphaAbstraction.causal_relation\n
+
+    Returns
+    -------
+    new_rights :: List of tuples\n
+        \tA new list of possible pair combinations to be added to pairs, not filtered
+    """
+    new_pairs = []
     for right_pair in right_pairs:
         if left_pair[0].issubset(right_pair[0]) or left_pair[1].issubset(right_pair[1]):
                         if not (
@@ -34,16 +61,36 @@ def find_alpha_pair(
                             alpha_parallel_relation_starts,alpha_causal_relation_starts,
                             alpha_parallel_relation_ends,alpha_causal_relation_ends)
                             ):
-                                new_rights.append(
+                                new_pairs.append(
                                      (left_pair[0] | right_pair[0], left_pair[1] | right_pair[1])
                                 )
-    return new_rights
+    return new_pairs
 
 def run_batch_alpha_pairs(
     t1:tuple,
-    pairs:list,
+    pairs:List[tuple],
     alpha_abstraction:ClassicAlphaAbstraction,
-    ) -> list :
+    ) -> List[tuple] :
+        """
+        run_batch_alpha_pairs
+        -----------
+        Generates new set of alpha pairs by paritioning work over a process pool of workers (CPU_CORES - 1 of machine)
+        then returns the new alpha pairs list for the next iteration of focused left pair (t1).
+
+        Parameters
+        ------------
+        t1 :: tuple\n
+            \tThe current focused `left_pair` to join on\n
+        pairs :: List[tuple]\n
+            \tThe current set of alpha pairs from iterations to attempt to join t1 to.
+        alpha_abstraction :: ClassicAlphaAbstraction\n
+            \tThe data structure abstraction for this selection of traces.
+
+        Returns
+        --------
+        pairs :: List[tuple]\n
+            \t A new list of unique alpha pairs ready for the next iteration of left pair (t1).
+        """
         # make starts and ends for relations
         alpha_parallel_relation_starts = [
         start 


### PR DESCRIPTION
I wanted to test out the capabilities of comparing a simple log to BPIC 2015 today. After leaving the alpha miner running for over one hour, I had no idea what was going on. So I have introduced some feedback to the classic version and took the process of getting new alpha pairs into a Process pool to use more than the one cpu.

If the log is without any parallel activities, the user would be better off using the original method but in complex logs, this helps the processing of alpha pairs to be a liner processing time over what seemed like an exponential processing time when pairs is large.

An example of the feedback while the alpha miner runs over the log can be seen below :
![image](https://user-images.githubusercontent.com/38652037/84654558-c2e22100-af52-11ea-8040-d173d0123732.png)
