### PR TITLE
Bug fix in bpmn.remove_flow, remove edge from graph object.

### DIFF
--- a/pm4py/objects/bpmn/bpmn_graph.py
+++ b/pm4py/objects/bpmn/bpmn_graph.py
@@ -212,6 +212,7 @@ class BPMN(object):
         if target in self.__nodes:
             target.remove_in_arc(flow)
         self.__flows.remove(flow)
+        self.__graph.remove_edge(source, target)
 
     def add_flow(self, flow):
         if type(flow) != BPMN.Flow:


### PR DESCRIPTION
Fixes #192
Tested the code.
```python
from pm4py.objects.bpmn.bpmn_graph import BPMN
import networkx as nx

bpmn = BPMN()
start = BPMN.Task(name="start")
a = BPMN.Task(name="a")
b = BPMN.Task(name="b")
f1 = BPMN.Flow(start, a)
f2 = BPMN.Flow(a, b)
f3 = BPMN.Flow(b, start)
bpmn.add_flow(f1)
bpmn.add_flow(f2)
bpmn.add_flow(f3)

# Flows: Previous
print(bpmn.get_flows())
"""
{id0fda534e-0342-459e-a2c6-93414c333af7@start -> id54e0e565-e06c-45d7-95b3-61035fa2b2ed@a,
 id1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b -> id0fda534e-0342-459e-a2c6-93414c333af7@start,
 id54e0e565-e06c-45d7-95b3-61035fa2b2ed@a -> id1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b}
"""

# Remove the flow
bpmn.remove_flow(f1)

# Flow is removed from bpmn model as we can see in the list
print(bpmn.get_flows())
"""
{id1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b -> id0fda534e-0342-459e-a2c6-93414c333af7@start,
 id54e0e565-e06c-45d7-95b3-61035fa2b2ed@a -> id1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b}
"""

# Also removed from graph object
print(bpmn.get_graph().edges)
"""
OutEdgeView([(54e0e565-e06c-45d7-95b3-61035fa2b2ed@a, 1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b), 
(1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b, 0fda534e-0342-459e-a2c6-93414c333af7@start)])
"""

graph = bpmn.get_graph()
print(graph.in_edges(start)) ## [(1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b, 0fda534e-0342-459e-a2c6-93414c333af7@start)])
print(graph.out_edges(start)) ## [] 
print(graph.in_edges(a)) ## []
print(graph.out_edges(a)) ## [(54e0e565-e06c-45d7-95b3-61035fa2b2ed@a, 1d23ba4c-a10e-4c01-a16b-6cc0981f5173@b)]
```
tested by plotting graph as well. 

```python
import matplotlib.pyplot as plt
maplabels = {i:i.get_name() for i in graph.nodes}
pos = nx.circular_layout(graph)
nx.draw(graph, arrows=True, with_labels=True, pos=pos, labels=maplabels)
plt.clf()
plt.savefig("test.png")
```
