### PR TITLE
Update variants_filter.py

### DIFF
--- a/pm4py/algo/filtering/log/variants/variants_filter.py
+++ b/pm4py/algo/filtering/log/variants/variants_filter.py
@@ -176,10 +176,10 @@ def filter_variants_variants_percentage(log, variants, variants_percentage=0.0):
         varcount = variant_count[i][1]
         if varcount < shall_break_under:
             break
-        percentage_already_added = already_added_sum / no_of_traces
         for trace in variants[variant]:
             filtered_log.append(trace)
         already_added_sum = already_added_sum + varcount
+        percentage_already_added = already_added_sum / no_of_traces
         if percentage_already_added >= variants_percentage:
             shall_break_under = varcount
 


### PR DESCRIPTION
Fix for filter_variants_variants_percentage to calculate the percentage_already_added directly after already_added_sum and not before, to update the break condition shall_break_under directly, so it would not take two more iterations to break but only one.