### PR TITLE
Unknown random distribution type

### DIFF
--- a/pm4py/objects/random_variables/random_variable.py
+++ b/pm4py/objects/random_variables/random_variable.py
@@ -20,6 +20,7 @@ from pm4py.objects.random_variables.constant0.random_variable import Constant0
 from pm4py.objects.random_variables.exponential.random_variable import Exponential
 from pm4py.objects.random_variables.normal.random_variable import Normal
 from pm4py.objects.random_variables.uniform.random_variable import Uniform
+from pm4py.objects.random_variables.unknown.random_variable import Unknown
 
 
 class RandomVariable(object):
@@ -48,6 +49,8 @@ class RandomVariable(object):
             self.random_variable.read_from_string(distribution_parameters)
         elif distribution_type == "IMMEDIATE":
             self.random_variable = Constant0()
+        else:
+            self.random_variable = Unknown()
 
     def get_distribution_type(self):
         """

--- a/pm4py/objects/random_variables/unknown/__init__.py
+++ b/pm4py/objects/random_variables/unknown/__init__.py
@@ -1,0 +1,17 @@
+'''
+    This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
+
+    PM4Py is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PM4Py is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
+'''
+from pm4py.objects.random_variables.unknown import random_variable

--- a/pm4py/objects/random_variables/unknown/random_variable.py
+++ b/pm4py/objects/random_variables/unknown/random_variable.py
@@ -1,0 +1,114 @@
+'''
+    This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
+
+    PM4Py is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PM4Py is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
+'''
+import sys
+
+from pm4py.objects.random_variables.basic_structure import BasicStructureRandomVariable
+
+
+class Unknown(BasicStructureRandomVariable):
+    """
+    Describes a variable of unknown distribution. This is useful as a fallback
+    letting properties be read even if the distribution is not known.
+    """
+
+    def __init__(self, loc=1, scale=1):
+        """
+        Constructor
+
+        Parameters
+        -----------
+        loc
+            Loc of the distribution (see docs.scipy.org/doc/scipy/reference/generated/scipy.stats.expon.html)
+        scale
+            Scale of the distribution
+        """
+        self.loc = loc
+        self.scale = scale
+        self.priority = 0
+        BasicStructureRandomVariable.__init__(self)
+
+    def read_from_string(self, distribution_parameters):
+        """
+        Initialize distribution parameters from string
+
+        Parameters
+        -----------
+        distribution_parameters
+            Current distribution parameters as exported on the Petri net
+        """
+        None
+        
+
+    def get_distribution_type(self):
+        """
+        Get current distribution type
+
+        Returns
+        -----------
+        distribution_type
+            String representing the distribution type
+        """
+        return "UNKNOWN"
+
+    def get_distribution_parameters(self):
+        """
+        Get a string representing distribution parameters
+
+        Returns
+        -----------
+        distribution_parameters
+            String representing distribution parameters
+        """
+        return "UNDEFINED"
+
+    def calculate_loglikelihood(self, values):
+        """
+        Calculate log likelihood
+
+        Parameters
+        ------------
+        values
+            Empirical values to work on
+
+        Returns
+        ------------
+        likelihood
+            Log likelihood that the values follows the distribution
+        """
+        None
+
+    def calculate_parameters(self, values):
+        """
+        Calculate parameters of the current distribution
+
+        Parameters
+        -----------
+        values
+            Empirical values to work on
+        """
+        None
+
+    def get_value(self):
+        """
+        Get a random value following the distribution
+
+        Returns
+        -----------
+        value
+            Value obtained following the distribution
+        """
+        None


### PR DESCRIPTION
The UNKNOWN distribution type which allows reading properties of unsupported distributions. Examples seen in stochastic process mining such as the `StochasticPetriNets` plugin in ProM include GAUSSIAN_KERNEL, DETERMINISTIC, GAMMA and HISTOGRAM. It is useful to be still be able to read weights, priorities, and so on in pm4py even if full support is not available.

An example snippet produced from running that SPN plugin on the `BPIC2013_closed.xes` reference log:

```xml
         <transition id="n14">
            <graphics>
               <dimension x="25.0" y="20.0"/>
            </graphics>
            <toolspecific tool="StochasticPetriNet" version="0.2">
               <property key="distributionType">GAUSSIAN_KERNEL</property>
               <property key="trainingData">duration;systemLoad;timestamp
0.0;506;1316178833000
8.659166666666666;730;1326434536000
1.7252777777777777;441;1329927075000
</property>
               <property key="weight">1475.0</property>
               <property key="invisible">false</property>
               <property key="distributionParameters">0.0;1.7252777777777777;8.659166666666666</property>
               <property key="priority">0</property>
            </toolspecific>
            <name>
               <text>Completed</text>
            </name>
         </transition>
```

I don't expect pm4py to drop everything and start supporting all distribution types. I'm not sure if it's even a good idea. But since there doesn't seem to be a central standard for extended stochastic net distributions, it is definitely useful if pm4py doesn't throw away what properties do exist and can be read. In my current use case, I don't need to perform any direct simulation, but I do need to be able to describe the net in question.

This is my first PR for pm4py. I am very open to feedback about alternative ways to do this, or pointers if I've just misunderstood the current capabilities of pm4py.

I ran the unit tests before and after. 4/326 failed both before and after. The failing tests all appear to be related to extensions outside core not affected by this patch. The SPN importer doesn't seem to have specific coverage, and that isn't changed by this patch.

Abbreviated test output (can share full on request)

```
ERROR: test_bpmn_importing_and_layouting (tests.bpmn_tests.BPMNTests)
ERROR: test_bpmn_layouting (tests.bpmn_tests.BPMNTests)
ERROR: test_emd_1 (tests.other_tests.OtherPartsTests)
ERROR: test_emd_2 (tests.other_tests.OtherPartsTests)

```
Ran 326 tests in 28.805s

FAILED (errors=4)

Cheers
Adam