### PR TITLE
add weights to petri_net visualization

### DIFF
--- a/pm4py/visualization/petri_net/common/visualize.py
+++ b/pm4py/visualization/petri_net/common/visualize.py
@@ -181,7 +181,10 @@ def graphviz_visualization(net, image_format="png", initial_marking=None, final_
         elif a in decorations and "color" in decorations[a]:
             viz.edge(str(id(a.source)), str(id(a.target)), color=decorations[a]["color"], fontsize=font_size, arrowhead=arrowhead)
         else:
-            viz.edge(str(id(a.source)), str(id(a.target)), fontsize=font_size, arrowhead=arrowhead)
+            if a.weight > 1:
+                viz.edge(str(id(a.source)), str(id(a.target)), fontsize=font_size, arrowhead=arrowhead, label=str(a.weight))
+            else:
+                viz.edge(str(id(a.source)), str(id(a.target)), fontsize=font_size, arrowhead=arrowhead)
     viz.attr(overlap='false')
 
     viz.format = image_format


### PR DESCRIPTION
Hi, I am using pm4py for a research project and it's great!
However I missed the weights of the arcs in my petrinet visualization.
I wasn't able to understand if and how I can pass decoration options down to the `graphviz_visualization(...)` function, so I just made weight labels the default if they are greater than 1.
