### PR TITLE
Removed hardcoded prefix and added missing parameters

### DIFF
--- a/pm4py/algo/filtering/log/attributes/attributes_filter.py
+++ b/pm4py/algo/filtering/log/attributes/attributes_filter.py
@@ -157,7 +157,7 @@ def apply_numeric_events(log: EventLog, int1: float, int2: float, parameters: Op
             list(filter(lambda x: attribute_key in x and (x[attribute_key] < int1 or x[attribute_key] > int2), stream)),
             attributes=log.attributes, extensions=log.extensions, classifiers=log.classifiers,
             omni_present=log.omni_present, properties=log.properties)
-    filtered_log = log_converter.apply(stream)
+    filtered_log = log_converter.apply(stream, parameters)
 
     return filtered_log
 
@@ -201,7 +201,7 @@ def apply_events(log: EventLog, values: List[str], parameters: Optional[Dict[Uni
                              extensions=log.extensions, classifiers=log.classifiers,
                              omni_present=log.omni_present, properties=log.properties)
 
-    filtered_log = log_converter.apply(stream)
+    filtered_log = log_converter.apply(stream, parameters)
 
     return filtered_log
 

--- a/pm4py/algo/filtering/log/attributes/attributes_filter.py
+++ b/pm4py/algo/filtering/log/attributes/attributes_filter.py
@@ -106,7 +106,7 @@ def apply_numeric(log: EventLog, int1: float, int2: float, parameters: Optional[
             attributes=log.attributes, extensions=log.extensions, classifiers=log.classifiers,
             omni_present=log.omni_present, properties=log.properties)
 
-    all_cases_ids = set(x["case:" + case_key] for x in stream)
+    all_cases_ids = set(x[case_key] for x in stream)
 
     filtered_log = EventLog(list(), attributes=log.attributes, extensions=log.extensions, classifiers=log.classifiers,
                             omni_present=log.omni_present, properties=log.properties)


### PR DESCRIPTION
Line 109:
The prefix requires to be also part in the case / process instance key. If I understand the [XES standard](https://xes-standard.org/_media/xes/xesstandarddefinition-2.0.pdf) correctly this should not be the case.

Line 160 & 204:
The methods _apply_ both have the parameter _parameters_. However, it is not set when the method is called. Without these parameters I have issues with my own process instance id (case id) _ident:piid__. PM4PY expects the case id to be _case:concept:name._ According to the XES Standard I assume that this is not a mandatory name to identify a case, even though the standard states in chapter 4: "One should consider using these standardized extensions". Whereas the _concept_ is such an extension.

The XES file that I wanted to process by PM4PY could be only processed after I made the changes above. Just as a reference how my file looks like:

```
<log xes.version="1.0" xes.features="nested-attributes" openxes.version="1.0RC7">
	<trace>
		<string key="ident:piid" value="1137202"/>
		<event>
			<int key="gas_price" value="3310000000"/>
			<string key="concept:name" value="conceived as mother"/>
			<string key="ident:eid" value="eid48"/>
			<string key="tx_from" value="0x0429c8d18b916dffa9d3ac0bc56d34d9014456ef"/>
			<int key="block_timestamp" value="1540814751"/>
			<int key="gas_used" value="79985"/>
			<int key="tx_blocknumber" value="6605180"/>
			<boolean key="tx_success" value="true"/>
			<string key="tx_hash" value="0x59a335a8db09575b3ed33c80bba64db59410f9d3189b16646905e88606c75e48"/>
			<string key="tx_to" value="0x06012c8cf97bead5deae237070f9587f8e7a266d"/>
			<date key="time:timestamp" value="2018-10-29T12:05:51Z"/>
			<string key="cost:currency" value="ETH"/>
			<string key="cost:total" value="0.00026475035"/>
		</event>
		<event>
			<int key="gas_price" value="29756973362"/>
			<string key="concept:name" value="birth"/>
			<string key="ident:eid" value="eid36"/>
			<string key="tx_from" value="0xa5f9bbb432baaad03f7031e2f650c5e7d6ce9f5b"/>
			<int key="block_timestamp" value="1540814078"/>
			<int key="gas_used" value="158774"/>
			<int key="tx_blocknumber" value="6605135"/>
			<boolean key="tx_success" value="true"/>
			<string key="tx_hash" value="0xfc17dfd95f62d3efcdfb670a4920f6c36aa9fcf83526ae1ff3a791cfdc44dd0e"/>
			<string key="tx_to" value="0x1b1262544cc56a7ac6de47ecac46394d017ff3e7"/>
			<date key="time:timestamp" value="2018-10-29T11:54:38Z"/>
			<string key="cost:currency" value="ETH"/>
			<string key="cost:total" value="0.004724633688578188"/>
		</event>
```
Note: This is just an excerpt of the larger file.