### PR TITLE
Locale readable stat

### DIFF
--- a/pm4py/objects/petri/performance_map.py
+++ b/pm4py/objects/petri/performance_map.py
@@ -370,7 +370,8 @@ def find_min_max_arc_performance(statistics, aggregation_measure):
     return min_performance, max_performance
 
 
-def aggregate_statistics(statistics, measure="frequency", aggregation_measure=None):
+def aggregate_statistics(statistics, measure="frequency", aggregation_measure=None,
+                         stat_locale: dict = {}):
     """
     Gets aggregated statistics
 
@@ -382,6 +383,8 @@ def aggregate_statistics(statistics, measure="frequency", aggregation_measure=No
         Desidered view on data (frequency or performance)
     aggregation_measure
         Aggregation measure (e.g. mean, min) to use
+    stat_locale
+        Dict to locale the stat strings
 
     Returns
     ----------
@@ -401,7 +404,7 @@ def aggregate_statistics(statistics, measure="frequency", aggregation_measure=No
             elif measure == "performance":
                 if statistics[elem]["performance"]:
                     aggr_stat = aggregate_stats(statistics, elem, aggregation_measure)
-                    aggr_stat_hr = human_readable_stat(aggr_stat)
+                    aggr_stat_hr = human_readable_stat(aggr_stat, stat_locale)
                     arc_penwidth = get_arc_penwidth(aggr_stat, min_arc_performance, max_arc_performance)
                     aggregated_statistics[elem] = {"label": aggr_stat_hr, "penwidth": str(arc_penwidth)}
         elif type(elem) is PetriNet.Transition:

--- a/pm4py/objects/petri_net/utils/performance_map.py
+++ b/pm4py/objects/petri_net/utils/performance_map.py
@@ -370,7 +370,8 @@ def find_min_max_arc_performance(statistics, aggregation_measure):
     return min_performance, max_performance
 
 
-def aggregate_statistics(statistics, measure="frequency", aggregation_measure=None):
+def aggregate_statistics(statistics, measure="frequency", aggregation_measure=None,
+                         stat_locale: dict = {}):
     """
     Gets aggregated statistics
 
@@ -382,7 +383,9 @@ def aggregate_statistics(statistics, measure="frequency", aggregation_measure=No
         Desidered view on data (frequency or performance)
     aggregation_measure
         Aggregation measure (e.g. mean, min) to use
-
+    stat_locale
+        Dict to locale the stat strings
+    
     Returns
     ----------
     aggregated_statistics
@@ -401,7 +404,7 @@ def aggregate_statistics(statistics, measure="frequency", aggregation_measure=No
             elif measure == "performance":
                 if statistics[elem]["performance"]:
                     aggr_stat = aggregate_stats(statistics, elem, aggregation_measure)
-                    aggr_stat_hr = human_readable_stat(aggr_stat)
+                    aggr_stat_hr = human_readable_stat(aggr_stat, stat_locale)
                     arc_penwidth = get_arc_penwidth(aggr_stat, min_arc_performance, max_arc_performance)
                     aggregated_statistics[elem] = {"label": aggr_stat_hr, "penwidth": str(arc_penwidth)}
         elif type(elem) is PetriNet.Transition:

--- a/pm4py/util/vis_utils.py
+++ b/pm4py/util/vis_utils.py
@@ -29,8 +29,10 @@ def human_readable_stat(timedelta_seconds, stat_locale: dict = {}):
 
     Parameters
     ----------
-    c
+    timedelta_seconds
         Timedelta expressed in seconds
+    stat_locale
+        Dict mapping stat strings
 
     Returns
     ----------

--- a/pm4py/util/vis_utils.py
+++ b/pm4py/util/vis_utils.py
@@ -23,7 +23,7 @@ MAX_EDGE_PENWIDTH_GRAPHVIZ = 2.6
 MIN_EDGE_PENWIDTH_GRAPHVIZ = 1.0
 
 
-def human_readable_stat(c):
+def human_readable_stat(timedelta_seconds, stat_locale: dict = {}):
     """
     Transform a timedelta expressed in seconds into a human readable string
 
@@ -37,24 +37,25 @@ def human_readable_stat(c):
     string
         Human readable string
     """
-    c = int(float(c))
-    years = c // 31104000
-    months = c // 2592000
-    days = c // 86400
-    hours = c // 3600 % 24
-    minutes = c // 60 % 60
-    seconds = c % 60
+    timedelta_seconds = int(float(timedelta_seconds))
+    years = timedelta_seconds // 31104000
+    months = timedelta_seconds // 2592000
+    days = timedelta_seconds // 86400
+    hours = timedelta_seconds // 3600 % 24
+    minutes = timedelta_seconds // 60 % 60
+    seconds = timedelta_seconds % 60
+    
     if years > 0:
-        return str(years) + "Y"
+        return str(years) + stat_locale.get("year", "Y")
     if months > 0:
-        return str(months) + "MO"
+        return str(months) + stat_locale.get("month", "MO")
     if days > 0:
-        return str(days) + "D"
+        return str(days) + stat_locale.get("day", "D")
     if hours > 0:
-        return str(hours) + "h"
+        return str(hours) + stat_locale.get("hour", "h")
     if minutes > 0:
-        return str(minutes) + "m"
-    return str(seconds) + "s"
+        return str(minutes) + stat_locale.get("minute", "m")
+    return str(seconds) + stat_locale.get("second", "s")
 
 
 def get_arc_penwidth(arc_measure, min_arc_measure, max_arc_measure):

--- a/pm4py/visualization/dfg/variants/frequency.py
+++ b/pm4py/visualization/dfg/variants/frequency.py
@@ -129,8 +129,9 @@ def get_activities_color(activities_count):
 
 
 def graphviz_visualization(activities_count, dfg, image_format="png", measure="frequency",
-                           max_no_of_edges_in_diagram=100000, start_activities=None, end_activities=None, soj_time=None, font_size="12", 
-                           bgcolor="transparent", stat_locale: dict = {}):
+                           max_no_of_edges_in_diagram=100000, start_activities=None, 
+                           end_activities=None, soj_time=None, font_size="12", 
+                           bgcolor="transparent"):
     """
     Do GraphViz visualization of a DFG graph
 
@@ -297,5 +298,5 @@ def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Opt
 
     return graphviz_visualization(activities_count, dfg, image_format=image_format, measure="frequency",
                                   max_no_of_edges_in_diagram=max_no_of_edges_in_diagram,
-                                  start_activities=start_activities, end_activities=end_activities, soj_time=soj_time,
-                                  font_size=font_size, bgcolor=bgcolor)
+                                  start_activities=start_activities, end_activities=end_activities, 
+                                  soj_time=soj_time, font_size=font_size, bgcolor=bgcolor)

--- a/pm4py/visualization/dfg/variants/frequency.py
+++ b/pm4py/visualization/dfg/variants/frequency.py
@@ -27,10 +27,7 @@ from pm4py.util import exec_utils
 from pm4py.statistics.sojourn_time.log import get as soj_time_get
 from enum import Enum
 from pm4py.util import constants
-from typing import Optional, Dict, Any, Union, Tuple
-from pm4py.objects.log.obj import EventLog, EventStream
-from pm4py.util import typing
-import graphviz
+from typing import Optional, Dict, Any, Tuple
 from pm4py.objects.log.obj import EventLog
 
 
@@ -132,8 +129,8 @@ def get_activities_color(activities_count):
 
 
 def graphviz_visualization(activities_count, dfg, image_format="png", measure="frequency",
-                           max_no_of_edges_in_diagram=100000, start_activities=None, end_activities=None, soj_time=None,
-                            font_size="12", bgcolor="transparent"):
+                           max_no_of_edges_in_diagram=100000, start_activities=None, end_activities=None, soj_time=None, font_size="12", 
+                           bgcolor="transparent", stat_locale: dict = {}):
     """
     Do GraphViz visualization of a DFG graph
 
@@ -155,7 +152,9 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
         End activities of the log
     soj_time
         For each activity, the sojourn time in the log
-
+    stat_locale
+        Dict to locale the stat strings
+    
     Returns
     -----------
     viz
@@ -212,7 +211,8 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
                      fillcolor=activities_color[act], fontsize=font_size)
             activities_map[act] = str(hash(act))
         else:
-            viz.node(str(hash(act)), act + " (" + human_readable_stat(soj_time[act]) + ")", fontsize=font_size)
+            stat_string = human_readable_stat(soj_time[act], stat_locale)
+            viz.node(str(hash(act)), act + f" ({stat_string})", fontsize=font_size)
             activities_map[act] = str(hash(act))
 
     # make edges addition always in the same order
@@ -223,7 +223,7 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
         if "frequency" in measure:
             label = str(dfg[edge])
         else:
-            label = human_readable_stat(dfg[edge])
+            label = human_readable_stat(dfg[edge], stat_locale)
         viz.edge(str(hash(edge[0])), str(hash(edge[1])), label=label, penwidth=str(penwidth[edge]), fontsize=font_size)
 
     start_activities_to_include = [act for act in start_activities if act in activities_map]
@@ -248,7 +248,7 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
     return viz
 
 
-def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Optional[Dict[Any, Any]] = None, activities_count : Dict[str, int] = None, soj_time: Dict[str, float] = None) -> graphviz.Digraph:
+def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Optional[Dict[Any, Any]] = None, activities_count : Dict[str, int] = None, soj_time: Dict[str, float] = None) -> Digraph:
     """
     Visualize a frequency directly-follows graph
 

--- a/pm4py/visualization/dfg/variants/performance.py
+++ b/pm4py/visualization/dfg/variants/performance.py
@@ -43,7 +43,7 @@ class Parameters(Enum):
     FONT_SIZE = "font_size"
     AGGREGATION_MEASURE = "aggregation_measure"
     BGCOLOR = "bgcolor"
-
+    STAT_LOCALE = "stat_locale"
 
 def get_min_max_value(dfg):
     """
@@ -129,7 +129,8 @@ def get_activities_color_soj_time(soj_time):
 
 
 def graphviz_visualization(activities_count, dfg, image_format="png", measure="frequency",
-                           max_no_of_edges_in_diagram=100000, start_activities=None, end_activities=None, soj_time=None, font_size="12", 
+                           max_no_of_edges_in_diagram=100000, start_activities=None, 
+                           end_activities=None, soj_time=None, font_size="12", 
                            bgcolor="transparent", stat_locale: dict = {}):
     """
     Do GraphViz visualization of a DFG graph
@@ -283,6 +284,7 @@ def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Opt
     activities = dfg_utils.get_activities_from_dfg(dfg)
     aggregation_measure = exec_utils.get_param_value(Parameters.AGGREGATION_MEASURE, parameters, "mean")
     bgcolor = exec_utils.get_param_value(Parameters.BGCOLOR, parameters, "transparent")
+    stat_locale = exec_utils.get_param_value(Parameters.STAT_LOCALE, parameters, {})
 
     if activities_count is None:
         if log is not None:
@@ -311,5 +313,6 @@ def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Opt
 
     return graphviz_visualization(activities_count, dfg, image_format=image_format, measure="performance",
                                   max_no_of_edges_in_diagram=max_no_of_edges_in_diagram,
-                                  start_activities=start_activities, end_activities=end_activities, soj_time=soj_time,
-                                  font_size=font_size, bgcolor=bgcolor)
+                                  start_activities=start_activities, end_activities=end_activities, 
+                                  soj_time=soj_time, font_size=font_size, bgcolor=bgcolor, 
+                                  stat_locale=stat_locale)

--- a/pm4py/visualization/dfg/variants/performance.py
+++ b/pm4py/visualization/dfg/variants/performance.py
@@ -25,13 +25,10 @@ from pm4py.util import xes_constants as xes
 from pm4py.visualization.common.utils import *
 from pm4py.util import exec_utils
 from pm4py.statistics.sojourn_time.log import get as soj_time_get
-from enum import Enum
 from pm4py.util import constants
+from enum import Enum
 
-from typing import Optional, Dict, Any, Union, Tuple
-from pm4py.objects.log.obj import EventLog, EventStream
-from pm4py.util import typing
-import graphviz
+from typing import Optional, Dict, Any, Tuple
 from pm4py.objects.log.obj import EventLog
 
 
@@ -132,8 +129,8 @@ def get_activities_color_soj_time(soj_time):
 
 
 def graphviz_visualization(activities_count, dfg, image_format="png", measure="frequency",
-                           max_no_of_edges_in_diagram=100000, start_activities=None, end_activities=None, soj_time=None,
-                           font_size="12", bgcolor="transparent"):
+                           max_no_of_edges_in_diagram=100000, start_activities=None, end_activities=None, soj_time=None, font_size="12", 
+                           bgcolor="transparent", stat_locale: dict = {}):
     """
     Do GraphViz visualization of a DFG graph
 
@@ -155,7 +152,9 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
         End activities of the log
     soj_time
         For each activity, the sojourn time in the log
-
+    stat_locale
+        Dict to locale the stat strings
+    
     Returns
     -----------
     viz
@@ -212,7 +211,8 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
                      fillcolor=activities_color[act], fontsize=font_size)
             activities_map[act] = str(hash(act))
         else:
-            viz.node(str(hash(act)), act + " (" + human_readable_stat(soj_time[act]) + ")", fontsize=font_size,
+            stat_string = human_readable_stat(soj_time[act], stat_locale)
+            viz.node(str(hash(act)), act + f" ({stat_string})", fontsize=font_size,
                      style='filled', fillcolor=activities_color[act])
             activities_map[act] = str(hash(act))
 
@@ -224,7 +224,7 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
         if "frequency" in measure:
             label = str(dfg[edge])
         else:
-            label = human_readable_stat(dfg[edge])
+            label = human_readable_stat(dfg[edge], stat_locale)
         viz.edge(str(hash(edge[0])), str(hash(edge[1])), label=label, penwidth=str(penwidth[edge]), fontsize=font_size)
 
     start_activities_to_include = [act for act in start_activities if act in activities_map]
@@ -248,7 +248,7 @@ def graphviz_visualization(activities_count, dfg, image_format="png", measure="f
     return viz
 
 
-def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Optional[Dict[Any, Any]] = None, activities_count : Dict[str, int] = None, soj_time: Dict[str, float] = None) -> graphviz.Digraph:
+def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Optional[Dict[Any, Any]] = None, activities_count : Dict[str, int] = None, soj_time: Dict[str, float] = None) -> Digraph:
     """
     Visualize a performance directly-follows graph
 

--- a/pm4py/visualization/heuristics_net/variants/pydotplus.py
+++ b/pm4py/visualization/heuristics_net/variants/pydotplus.py
@@ -28,6 +28,7 @@ from typing import Optional, Dict, Any, Union, Tuple
 
 class Parameters(Enum):
     FORMAT = "format"
+    STAT_LOCALE = "stat_locale"
 
 
 def get_corr_hex(num):
@@ -126,6 +127,7 @@ def apply(heu_net: HeuristicsNet, parameters: Optional[Dict[Union[str, Parameter
     parameters
         Possible parameters of the algorithm, including:
             - Parameters.FORMAT
+            - Parameters.STAT_LOCALE
 
     Returns
     ------------
@@ -136,6 +138,7 @@ def apply(heu_net: HeuristicsNet, parameters: Optional[Dict[Union[str, Parameter
         parameters = {}
 
     image_format = exec_utils.get_param_value(Parameters.FORMAT, parameters, "png")
+    stat_locale = exec_utils.get_param_value(Parameters.STAT_LOCALE, parameters, {})
 
     graph = pydotplus.Dot(strict=True)
     graph.obj_dict['attributes']['bgcolor'] = 'transparent'
@@ -154,9 +157,10 @@ def apply(heu_net: HeuristicsNet, parameters: Optional[Dict[Union[str, Parameter
                                label=node_name + " (" + str(node_occ) + ")", fillcolor=node.get_fill_color(graycolor),
                                fontcolor=node.get_font_color())
         else:
+            time_str = f" ({human_readable_stat(heu_net.sojourn_times[node_name], stat_locale)})" if (
+                node_name in heu_net.sojourn_times) else node_name + " (0s)"
             n = pydotplus.Node(name=node_name, shape="box", style="filled",
-                               label=node_name + " (" + human_readable_stat(heu_net.sojourn_times[
-                                                                                node_name]) + ")" if node_name in heu_net.sojourn_times else node_name + " (0s)",
+                               label=node_name + time_str,
                                fillcolor=node.get_fill_color(graycolor),
                                fontcolor=node.get_font_color())
         corr_nodes[node] = n
@@ -188,7 +192,7 @@ def apply(heu_net: HeuristicsNet, parameters: Optional[Dict[Union[str, Parameter
                                                penwidth=edge.get_penwidth(this_pen_width))
                         else:
                             e = pydotplus.Edge(src=corr_nodes[node], dst=corr_nodes[other_node],
-                                               label=edge.net_name + " (" + human_readable_stat(repr_value) + ")",
+                                               label=f"{edge.net_name} ({human_readable_stat(repr_value, stat_locale)})",
                                                color=edge.get_color(),
                                                fontcolor=edge.get_font_color(),
                                                penwidth=edge.get_penwidth(this_pen_width))
@@ -200,7 +204,7 @@ def apply(heu_net: HeuristicsNet, parameters: Optional[Dict[Union[str, Parameter
                                                penwidth=edge.get_penwidth(this_pen_width))
                         else:
                             e = pydotplus.Edge(src=corr_nodes[node], dst=corr_nodes[other_node],
-                                               label=human_readable_stat(repr_value),
+                                               label=human_readable_stat(repr_value, stat_locale),
                                                color=edge.get_color(),
                                                fontcolor=edge.get_font_color(),
                                                penwidth=edge.get_penwidth(this_pen_width))

--- a/pm4py/visualization/petri_net/util/vis_trans_shortest_paths.py
+++ b/pm4py/visualization/petri_net/util/vis_trans_shortest_paths.py
@@ -158,7 +158,7 @@ def get_shortest_paths(net, enable_extension=False):
 
 
 def get_decorations_from_dfg_spaths_acticount(net, dfg, spaths, activities_count, variant="frequency",
-                                              aggregation_measure=None):
+                                              aggregation_measure=None, stat_locale: dict = {}):
     """
     Get decorations from Petrinet without doing any replay
     but based on DFG measures, shortest paths and activities count.
@@ -179,6 +179,8 @@ def get_decorations_from_dfg_spaths_acticount(net, dfg, spaths, activities_count
         Describe how to decorate the Petri net (could be frequency or performance)
     aggregation_measure
         Specifies the aggregation measure
+    stat_locale
+        Dict to locale the stat strings
 
     Returns
     -----------
@@ -226,7 +228,7 @@ def get_decorations_from_dfg_spaths_acticount(net, dfg, spaths, activities_count
         arcs_max_value = max(list(decorations_int.values()))
         for arc in decorations_int:
             if "performance" in variant:
-                arc_label = human_readable_stat(decorations_int[arc])
+                arc_label = human_readable_stat(decorations_int[arc], stat_locale)
             else:
                 arc_label = str(decorations_int[arc])
             decorations[arc] = {"label": arc_label,

--- a/pm4py/visualization/petri_net/variants/greedy_decoration_performance.py
+++ b/pm4py/visualization/petri_net/variants/greedy_decoration_performance.py
@@ -37,6 +37,7 @@ class Parameters(Enum):
     TIMESTAMP_KEY = PARAMETER_CONSTANT_TIMESTAMP_KEY
     AGGREGATION_MEASURE = "aggregationMeasure"
     FONT_SIZE = "font_size"
+    STAT_LOCALE = "stat_locale"
 
 
 def get_decorated_net(net, initial_marking, final_marking, log, parameters=None, variant="frequency"):
@@ -70,6 +71,7 @@ def get_decorated_net(net, initial_marking, final_marking, log, parameters=None,
                                                      "sum" if "frequency" in variant else "mean")
 
     activity_key = exec_utils.get_param_value(Parameters.ACTIVITY_KEY, parameters, xes.DEFAULT_NAME_KEY)
+    stat_locale = exec_utils.get_param_value(Parameters.STAT_LOCALE, parameters, {})
 
     # we find the DFG
     if variant == "performance":
@@ -83,7 +85,8 @@ def get_decorated_net(net, initial_marking, final_marking, log, parameters=None,
     aggregated_statistics = get_decorations_from_dfg_spaths_acticount(net, dfg, spaths,
                                                                       activities_count,
                                                                       variant=variant,
-                                                                      aggregation_measure=aggregation_measure)
+                                                                      aggregation_measure=aggregation_measure,
+                                                                      stat_locale=stat_locale)
 
     return visualize.apply(net, initial_marking, final_marking, parameters=parameters,
                            decorations=aggregated_statistics)

--- a/pm4py/visualization/petri_net/variants/token_decoration_frequency.py
+++ b/pm4py/visualization/petri_net/variants/token_decoration_frequency.py
@@ -59,7 +59,7 @@ def get_decorations(log, net, initial_marking, final_marking, parameters=None, m
     ht_perf_method
         Method to use in order to annotate hidden transitions (performance value could be put on the last possible
         point (last) or in the first possible point (first)
-
+    
     Returns
     ------------
     decorations

--- a/pm4py/visualization/petri_net/variants/token_decoration_performance.py
+++ b/pm4py/visualization/petri_net/variants/token_decoration_performance.py
@@ -35,6 +35,7 @@ class Parameters(Enum):
     TIMESTAMP_KEY = PARAMETER_CONSTANT_TIMESTAMP_KEY
     AGGREGATION_MEASURE = "aggregationMeasure"
     FONT_SIZE = "font_size"
+    STAT_LOCALE = "stat_locale"
 
 
 def get_decorations(log, net, initial_marking, final_marking, parameters=None, measure="frequency",
@@ -72,6 +73,7 @@ def get_decorations(log, net, initial_marking, final_marking, parameters=None, m
     activity_key = exec_utils.get_param_value(Parameters.ACTIVITY_KEY, parameters, xes_constants.DEFAULT_NAME_KEY)
     timestamp_key = exec_utils.get_param_value(Parameters.TIMESTAMP_KEY, parameters,
                                                xes_constants.DEFAULT_TIMESTAMP_KEY)
+    stat_locale = exec_utils.get_param_value(Parameters.STAT_LOCALE, parameters, {})
 
     variants_idx = variants_get.get_variants_from_log_trace_idx(log, parameters=parameters)
     variants = variants_get.convert_variants_trace_idx_to_trace_obj(log, variants_idx)
@@ -92,7 +94,8 @@ def get_decorations(log, net, initial_marking, final_marking, parameters=None, m
                                                                    ht_perf_method=ht_perf_method)
 
     aggregated_statistics = performance_map.aggregate_statistics(element_statistics, measure=measure,
-                                                                 aggregation_measure=aggregation_measure)
+                                                                 aggregation_measure=aggregation_measure,
+                                                                 stat_locale=stat_locale)
 
     return aggregated_statistics
 

--- a/pm4py/visualization/petrinet/parameters.py
+++ b/pm4py/visualization/petrinet/parameters.py
@@ -26,3 +26,4 @@ class Parameters(Enum):
     TIMESTAMP_KEY = PARAMETER_CONSTANT_TIMESTAMP_KEY
     AGGREGATION_MEASURE = "aggregationMeasure"
     FONT_SIZE = "font_size"
+    STAT_LOCALE = "stat_locale"

--- a/pm4py/visualization/petrinet/util/vis_trans_shortest_paths.py
+++ b/pm4py/visualization/petrinet/util/vis_trans_shortest_paths.py
@@ -158,7 +158,7 @@ def get_shortest_paths(net, enable_extension=False):
 
 
 def get_decorations_from_dfg_spaths_acticount(net, dfg, spaths, activities_count, variant="frequency",
-                                              aggregation_measure=None):
+                                              aggregation_measure=None, stat_locale: dict = {}):
     """
     Get decorations from Petrinet without doing any replay
     but based on DFG measures, shortest paths and activities count.
@@ -179,7 +179,9 @@ def get_decorations_from_dfg_spaths_acticount(net, dfg, spaths, activities_count
         Describe how to decorate the Petri net (could be frequency or performance)
     aggregation_measure
         Specifies the aggregation measure
-
+    stat_locale
+        Dict to locale the stat strings
+    
     Returns
     -----------
     decorations
@@ -226,7 +228,7 @@ def get_decorations_from_dfg_spaths_acticount(net, dfg, spaths, activities_count
         arcs_max_value = max(list(decorations_int.values()))
         for arc in decorations_int:
             if "performance" in variant:
-                arc_label = human_readable_stat(decorations_int[arc])
+                arc_label = human_readable_stat(decorations_int[arc], stat_locale)
             else:
                 arc_label = str(decorations_int[arc])
             decorations[arc] = {"label": arc_label,

--- a/pm4py/visualization/petrinet/variants/greedy_decoration_performance.py
+++ b/pm4py/visualization/petrinet/variants/greedy_decoration_performance.py
@@ -55,6 +55,7 @@ def get_decorated_net(net, initial_marking, final_marking, log, parameters=None,
                                                      "sum" if "frequency" in variant else "mean")
 
     activity_key = exec_utils.get_param_value(Parameters.ACTIVITY_KEY, parameters, xes.DEFAULT_NAME_KEY)
+    stat_locale = exec_utils.get_param_value(Parameters.STAT_LOCALE, parameters, {})
 
     # we find the DFG
     if variant == "performance":
@@ -68,7 +69,8 @@ def get_decorated_net(net, initial_marking, final_marking, log, parameters=None,
     aggregated_statistics = get_decorations_from_dfg_spaths_acticount(net, dfg, spaths,
                                                                       activities_count,
                                                                       variant=variant,
-                                                                      aggregation_measure=aggregation_measure)
+                                                                      aggregation_measure=aggregation_measure,
+                                                                      stat_locale=stat_locale)
 
     return visualize.apply(net, initial_marking, final_marking, parameters=parameters,
                            decorations=aggregated_statistics)

--- a/pm4py/visualization/petrinet/variants/token_decoration_frequency.py
+++ b/pm4py/visualization/petrinet/variants/token_decoration_frequency.py
@@ -18,8 +18,8 @@ from pm4py.algo.conformance.tokenreplay import algorithm as token_replay
 from pm4py.statistics.variants.log import get as variants_get
 from pm4py.visualization.petrinet.common import visualize
 from pm4py.visualization.petrinet.util import performance_map
-from pm4py.util import exec_utils, xes_constants
 from pm4py.visualization.petrinet.parameters import Parameters
+from pm4py.util import exec_utils, xes_constants
 
 
 def get_decorations(log, net, initial_marking, final_marking, parameters=None, measure="frequency",

--- a/pm4py/visualization/petrinet/variants/token_decoration_performance.py
+++ b/pm4py/visualization/petrinet/variants/token_decoration_performance.py
@@ -18,8 +18,8 @@ from pm4py.algo.conformance.tokenreplay import algorithm as token_replay
 from pm4py.statistics.variants.log import get as variants_get
 from pm4py.visualization.petrinet.common import visualize
 from pm4py.visualization.petrinet.util import performance_map
-from pm4py.util import exec_utils, xes_constants
 from pm4py.visualization.petrinet.parameters import Parameters
+from pm4py.util import exec_utils, xes_constants
 
 
 def get_decorations(log, net, initial_marking, final_marking, parameters=None, measure="frequency",
@@ -57,6 +57,7 @@ def get_decorations(log, net, initial_marking, final_marking, parameters=None, m
     activity_key = exec_utils.get_param_value(Parameters.ACTIVITY_KEY, parameters, xes_constants.DEFAULT_NAME_KEY)
     timestamp_key = exec_utils.get_param_value(Parameters.TIMESTAMP_KEY, parameters,
                                                xes_constants.DEFAULT_TIMESTAMP_KEY)
+    stat_locale = exec_utils.get_param_value(Parameters.STAT_LOCALE, parameters, {})
 
     variants_idx = variants_get.get_variants_from_log_trace_idx(log, parameters=parameters)
     variants = variants_get.convert_variants_trace_idx_to_trace_obj(log, variants_idx)
@@ -77,7 +78,8 @@ def get_decorations(log, net, initial_marking, final_marking, parameters=None, m
                                                                    ht_perf_method=ht_perf_method)
 
     aggregated_statistics = performance_map.aggregate_statistics(element_statistics, measure=measure,
-                                                                 aggregation_measure=aggregation_measure)
+                                                                 aggregation_measure=aggregation_measure,
+                                                                 stat_locale=stat_locale)
 
     return aggregated_statistics
 


### PR DESCRIPTION
Can pass a stat_locale param to human_readable_stat function. closes #272 
Was added docstrings and the new Parameter in the **perfomance** functions.

I tried to add a global variable to modify without pass parameter, but this just can do it through classes instances... And would break out the code pattern.

Eg of use:

```py
from pm4py.visualization.dfg.variants.performance import apply as dfg_performance
from pm4py.visualization.dfg.variants.performance import Parameters

from pm4py.objects.log.importer.xes import importer as xes_importer
from pm4py.algo.discovery.dfg import algorithm as dfg_discovery

LOG_PATH = "teste.xes"

# The locale dict
BR_LOCALE_STAT = {
    "year": "A",
    "month": "M"
}

log = xes_importer.apply(LOG_PATH)
dfg = dfg_discovery.apply(log)

# The stat_locale parameter will pass to human_readable_stat function
dfg_performance.apply(dfg, log, parameters = {
    Parameters.STAT_LOCALE: BR_LOCALE_STAT
}).render()
```

I thought of create a Parameter Enum to facilite the declation of dict, like:

```py
from pm4py.utils.vis_utils import LocaleParameters

BR_LOCALE_STAT = {
    LocaleParameters.YEAR: "A",
    LocaleParameters.MONTH: "M"
}
```

Awaiting the next steps and what needs to be changed.