### PR TITLE
Added support for BPMN Gateway Direction properties

### DIFF
--- a/pm4py/objects/bpmn/exporter/variants/etree.py
+++ b/pm4py/objects/bpmn/exporter/variants/etree.py
@@ -110,15 +110,15 @@ def get_xml_string(bpmn_graph, parameters=None):
             task = ET.SubElement(process, node.type, {"id": node.get_id(), "name": node.get_name()})
         elif isinstance(node, BPMN.ExclusiveGateway):
             task = ET.SubElement(process, "exclusiveGateway",
-                                 {"id": node.get_id(), "gatewayDirection": "unspecified",
+                                 {"id": node.get_id(), "gatewayDirection": node.get_gatewayDirection(),
                                   "name": ""})
         elif isinstance(node, BPMN.ParallelGateway):
             task = ET.SubElement(process, "parallelGateway",
-                                 {"id": node.get_id(), "gatewayDirection": "unspecified",
+                                 {"id": node.get_id(), "gatewayDirection": node.get_gatewayDirection(),
                                   "name": ""})
         elif isinstance(node, BPMN.InclusiveGateway):
             task = ET.SubElement(process, "inclusiveGateway",
-                                 {"id": node.get_id(), "gatewayDirection": "unspecified",
+                                 {"id": node.get_id(), "gatewayDirection": node.get_gatewayDirection(),
                                   "name": ""})
         else:
             raise Exception("Unexpected node type.")

--- a/pm4py/objects/bpmn/obj.py
+++ b/pm4py/objects/bpmn/obj.py
@@ -124,16 +124,34 @@ class BPMN(object):
         def __init__(self, name="", gatewayDirection="Unspecified", in_arcs=None, out_arcs=None):
             BPMN.BPMNNode.__init__(self, name, in_arcs, out_arcs)
             self.__gatewayDirection = gatewayDirection
+        
+        def get_gatewayDirection(self):
+            return self.__gatewayDirection
+        
+        def set_gatewayDirection(self, direction : str):
+            self.__gatewayDirection = direction
 
     class ExclusiveGateway(BPMNNode):
         def __init__(self, name="", gatewayDirection="Unspecified", in_arcs=None, out_arcs=None):
             BPMN.BPMNNode.__init__(self, name, in_arcs, out_arcs)
             self.__gatewayDirection = gatewayDirection
+        
+        def get_gatewayDirection(self):
+            return self.__gatewayDirection
+        
+        def set_gatewayDirection(self, direction : str):
+            self.__gatewayDirection = direction
 
     class InclusiveGateway(BPMNNode):
         def __init__(self, name="", gatewayDirection="Unspecified", in_arcs=None, out_arcs=None):
             BPMN.BPMNNode.__init__(self, name, in_arcs, out_arcs)
             self.__gatewayDirection = gatewayDirection
+        
+        def get_gatewayDirection(self):
+            return self.__gatewayDirection
+        
+        def set_gatewayDirection(self, direction : str):
+            self.__gatewayDirection = direction
 
     class Flow(object):
         def __init__(self, source, target, name=""):


### PR DESCRIPTION
BPMN Gateways already included properties named "__gatewayDirection". They have now been made accessible via appropriate methods and they are now also taken into consideration during export of the model.