### PR TITLE
Fix `pm4py.visualization.dfg.variants.performance.apply` in case `dfg` contains all measures

### DIFF
--- a/pm4py/visualization/dfg/variants/performance.py
+++ b/pm4py/visualization/dfg/variants/performance.py
@@ -335,6 +335,19 @@ def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Opt
     if stat_locale is None:
         stat_locale = {}
 
+    # if all the aggregation measures are provided for a given key,
+    # then pick one of the values for the representation
+    dfg0 = dfg
+    dfg = {}
+    for key in dfg0:
+        try:
+            if aggregation_measure in dfg0[key]:
+                dfg[key] = dfg0[key][aggregation_measure]
+            else:
+                dfg[key] = dfg0[key]
+        except:
+            dfg[key] = dfg0[key]
+
     if activities_count is None:
         if log is not None:
             activities_count = attr_get.get_attribute_values(log, activity_key, parameters=parameters)
@@ -354,19 +367,6 @@ def apply(dfg: Dict[Tuple[str, str], int], log: EventLog = None, parameters: Opt
             soj_time = soj_time_get.apply(log, parameters=parameters)
         else:
             soj_time = {key: -1 for key in activities}
-
-    # if all the aggregation measures are provided for a given key,
-    # then pick one of the values for the representation
-    dfg0 = dfg
-    dfg = {}
-    for key in dfg0:
-        try:
-            if aggregation_measure in dfg0[key]:
-                dfg[key] = dfg0[key][aggregation_measure]
-            else:
-                dfg[key] = dfg0[key]
-        except:
-            dfg[key] = dfg0[key]
 
     return graphviz_visualization(activities_count, dfg, image_format=image_format, measure="performance",
                                   max_no_of_edges_in_diagram=max_no_of_edges_in_diagram,


### PR DESCRIPTION
Calling `pm4py.visualization.dfg.variants.performance.apply` with a DFG that contains all aggregation measures (e.g. one returned from `pm4py.discover_dfg` would result in an error on the line 347 (in the old file), since in that case `dfg[el]` would be a dictionary containing all aggregation measures which cannot be added to `activities_count[el[1]]`, which is an integer.

The snippet from lines 358-369 (again in the old file) is actually responsible for filtering out all other aggregation measures, which really should be put in the beginning before anything else is processed.