### PR TITLE
Add functionalities to directly export a performance DFG

### DIFF
--- a/pm4py/__init__.py
+++ b/pm4py/__init__.py
@@ -58,7 +58,7 @@ from pm4py.vis import view_petri_net, save_vis_petri_net, view_dfg, save_vis_dfg
     view_dotted_chart, save_vis_dotted_chart, view_performance_spectrum, save_vis_performance_spectrum, view_case_duration_graph, view_events_per_time_graph, save_vis_case_duration_graph, \
     save_vis_events_per_time_graph, view_events_distribution_graph, save_vis_events_distribution_graph, view_performance_dfg, save_vis_performance_dfg, \
     view_ocpn, save_vis_ocpn, view_network_analysis, save_vis_network_analysis
-from pm4py.write import write_xes, write_petri_net, write_process_tree, write_dfg, write_bpmn, write_pnml, write_ptml, write_ocel
+from pm4py.write import write_xes, write_petri_net, write_process_tree, write_dfg, write_performance_dfg, write_bpmn, write_pnml, write_ptml, write_ocel
 from pm4py.org import discover_handover_of_work_network, discover_activity_based_resource_similarity, discover_subcontracting_network, discover_working_together_network, discover_organizational_roles, discover_network_analysis
 from pm4py.ml import split_train_test, get_prefixes_from_log
 from pm4py.ocel import ocel_get_object_types, ocel_get_attribute_names, ocel_flattening, ocel_object_type_activities, ocel_objects_ot_count

--- a/pm4py/objects/dfg/exporter/exporter.py
+++ b/pm4py/objects/dfg/exporter/exporter.py
@@ -16,12 +16,13 @@
 '''
 from enum import Enum
 
-from pm4py.objects.dfg.exporter.variants import classic
+from pm4py.objects.dfg.exporter.variants import classic, performance
 from pm4py.util import exec_utils
 
 
 class Variants(Enum):
     CLASSIC = classic
+    PERFORMANCE = performance
 
 
 DEFAULT_VARIANT = Variants.CLASSIC

--- a/pm4py/objects/dfg/exporter/variants/__init__.py
+++ b/pm4py/objects/dfg/exporter/variants/__init__.py
@@ -14,4 +14,4 @@
     You should have received a copy of the GNU General Public License
     along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
 '''
-from pm4py.objects.dfg.exporter.variants import classic
+from pm4py.objects.dfg.exporter.variants import classic, performance

--- a/pm4py/objects/dfg/exporter/variants/performance.py
+++ b/pm4py/objects/dfg/exporter/variants/performance.py
@@ -1,0 +1,146 @@
+'''
+    This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
+
+    PM4Py is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    PM4Py is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
+'''
+from pm4py.util import exec_utils
+from enum import Enum
+from collections import Counter
+from pm4py.objects.dfg.utils import dfg_utils
+from pm4py.util.constants import DEFAULT_ENCODING
+
+
+class Parameters(Enum):
+    START_ACTIVITIES = "start_activities"
+    END_ACTIVITIES = "end_activities"
+    AGGREGATION_MEASURE = "aggregation_measure"
+
+
+def export_line_by_line(dfg, parameters=None):
+    """
+    Exports a performance DFG into the .dfg format
+    - Line by line yielding
+
+    Parameters
+    --------------
+    dfg
+        DFG
+    parameters
+        Parameters of the algorithm
+
+    Returns
+    --------------
+    line
+        Lines of the .dfg file (yielded one-by-one)
+    """
+    if parameters is None:
+        parameters = {}
+
+    start_activities = exec_utils.get_param_value(Parameters.START_ACTIVITIES, parameters,
+                                                  Counter(dfg_utils.infer_start_activities(dfg)))
+    end_activities = exec_utils.get_param_value(Parameters.END_ACTIVITIES, parameters,
+                                                Counter(dfg_utils.infer_end_activities(dfg)))
+    aggregation_measure = exec_utils.get_param_value(Parameters.AGGREGATION_MEASURE, parameters, "mean")
+
+    if len(start_activities) == 0:
+        raise Exception(
+            "error: impossible to determine automatically the start activities from the DFG. Please specify them manually through the START_ACTIVITIES parameter")
+
+    if len(end_activities) == 0:
+        raise Exception(
+            "error: impossible to determine automatically the end activities from the DFG. Please specify them manually through the END_ACTIVITIES parameter")
+
+    activities = list(set(x[0] for x in dfg).union(set(x[1] for x in dfg)))
+
+    # if all the aggregation measures are provided for a given key,
+    # then pick one of the values for the representation
+    dfg0 = dfg
+    dfg = {}
+    for key in dfg0:
+        try:
+            if aggregation_measure in dfg0[key]:
+                dfg[key] = dfg0[key][aggregation_measure]
+            else:
+                dfg[key] = dfg0[key]
+        except:
+            dfg[key] = dfg0[key]
+
+    yield "%d\n" % (len(activities))
+    for act in activities:
+        yield "%s\n" % (act)
+
+    yield "%d\n" % (len(start_activities))
+    for act, count in start_activities.items():
+        yield "%dx%d\n" % (activities.index(act), count)
+
+    yield "%d\n" % (len(end_activities))
+    for act, count in end_activities.items():
+        yield "%dx%d\n" % (activities.index(act), count)
+
+    for el, count in dfg.items():
+        yield "%d>%dx%d\n" % (activities.index(el[0]), activities.index(el[1]), count)
+
+
+def apply(dfg, output_path, parameters=None):
+    """
+    Exports a performance DFG into a .dfg file
+
+    Parameters
+    ----------------
+    dfg
+        Directly-Follows Graph
+    output_path
+        Output path
+    parameters
+        Parameters of the algorithm, including:
+            Parameters.START_ACTIVITIES => Start activities of the DFG
+            Parameters.END_ACTIVITIES => End activities of the DFG
+    """
+    if parameters is None:
+        parameters = {}
+
+    F = open(output_path, "wb")
+    for row in export_line_by_line(dfg, parameters=parameters):
+        F.write(row.encode(DEFAULT_ENCODING))
+    F.close()
+
+
+def export_as_string(dfg, parameters=None):
+    """
+    Exports a performance DFG as a string
+
+    Parameters
+    --------------
+    dfg
+        Directly-Follows Graph
+    parameters
+        Parameters of the algorithm, including:
+            Parameters.START_ACTIVITIES => Start activities of the DFG
+            Parameters.END_ACTIVITIES => End activities of the DFG
+
+    Returns
+    --------------
+    binary_string
+        Binary string
+    """
+    if parameters is None:
+        parameters = {}
+
+    ret = []
+    for row in export_line_by_line(dfg, parameters=parameters):
+        ret.append(row)
+    ret = "".join(ret)
+    ret = ret.encode(DEFAULT_ENCODING)
+
+    return ret

--- a/pm4py/write.py
+++ b/pm4py/write.py
@@ -161,6 +161,32 @@ def write_dfg(dfg: dict, start_activities: dict, end_activities: dict, file_path
                        parameters={dfg_exporter.Variants.CLASSIC.value.Parameters.START_ACTIVITIES: start_activities,
                                    dfg_exporter.Variants.CLASSIC.value.Parameters.END_ACTIVITIES: end_activities})
 
+def write_performance_dfg(dfg: dict, start_activities: dict, end_activities: dict, file_path: str, aggregation_measure="mean"):
+    """
+    Exports a performance DFG
+
+    Parameters
+    -------------
+    dfg
+        DFG
+    start_activities
+        Start activities
+    end_activities
+        End activities
+    file_path
+        Destination path
+    aggregation_measure
+        Aggregation measure (default: mean): mean, median, min, max, sum, stdev
+
+    Returns
+    ------------
+    void
+    """
+    from pm4py.objects.dfg.exporter import exporter as dfg_exporter
+    dfg_exporter.apply(dfg, file_path, variant = dfg_exporter.Variants.PERFORMANCE,
+                       parameters={dfg_exporter.Variants.PERFORMANCE.value.Parameters.START_ACTIVITIES: start_activities,
+                                   dfg_exporter.Variants.PERFORMANCE.value.Parameters.END_ACTIVITIES: end_activities,
+                                   dfg_exporter.Variants.PERFORMANCE.value.Parameters.AGGREGATION_MEASURE: aggregation_measure})
 
 def write_bpmn(bpmn_graph: BPMN, file_path: str, enable_layout: bool = True):
     """


### PR DESCRIPTION
To export a performance DFG that contains all aggregation measures (e.g. one returned by `pm4py.discover_performance_dfg`), one must first select an aggregation measure of interest and manually filter out all others. I have therefore added a new variant to `pm4py.objects.dfg.exporter` as well as a new function `write_performance_dfg` to `pm4py.write` that do this automatically.