### PR TITLE
Included 2 new parameters for the BASIC PLAYOUT for Petri Nets: initial_timestamp and initial_case_id

### DIFF
--- a/pm4py/algo/simulation/playout/petri_net/variants/basic_playout.py
+++ b/pm4py/algo/simulation/playout/petri_net/variants/basic_playout.py
@@ -37,9 +37,12 @@ class Parameters(Enum):
     NO_TRACES = "noTraces"
     MAX_TRACE_LENGTH = "maxTraceLength"
     PETRI_SEMANTICS = "petri_semantics"
+    INITIAL_TIMESTAMP = "initial_timestamp"
+    INITIAL_CASE_ID = "initial_case_id"
 
 
 def apply_playout(net, initial_marking, no_traces=100, max_trace_length=100,
+                  initial_timestamp=10000000, initial_case_id=0,
                   case_id_key=xes_constants.DEFAULT_TRACEID_KEY,
                   activity_key=xes_constants.DEFAULT_NAME_KEY, timestamp_key=xes_constants.DEFAULT_TIMESTAMP_KEY,
                   final_marking=None, return_visited_elements=False, semantics=petri_net.semantics.ClassicSemantics()):
@@ -56,6 +59,10 @@ def apply_playout(net, initial_marking, no_traces=100, max_trace_length=100,
         Number of traces to generate
     max_trace_length
         Maximum number of events per trace (do break)
+    initial_timestamp
+        Increased timestamp from 1970 for the first event
+    initial_case_id
+        Case id of the first event
     case_id_key
         Trace attribute that is the case ID
     activity_key
@@ -68,7 +75,7 @@ def apply_playout(net, initial_marking, no_traces=100, max_trace_length=100,
         Semantics of the Petri net to be used (default: petri_net.semantics.ClassicSemantics())
     """
     # assigns to each event an increased timestamp from 1970
-    curr_timestamp = 10000000
+    curr_timestamp = initial_timestamp
     all_visited_elements = []
 
     for i in range(no_traces):
@@ -104,7 +111,7 @@ def apply_playout(net, initial_marking, no_traces=100, max_trace_length=100,
 
     for index, visited_elements in enumerate(all_visited_elements):
         trace = log_instance.Trace()
-        trace.attributes[case_id_key] = str(index)
+        trace.attributes[case_id_key] = str(index+initial_case_id)
         for element in visited_elements:
             if type(element) is PetriNet.Transition and element.label is not None:
                 event = log_instance.Event()
@@ -135,6 +142,8 @@ def apply(net: PetriNet, initial_marking: Marking, final_marking: Marking = None
         Parameters of the algorithm:
             Parameters.NO_TRACES -> Number of traces of the log to generate
             Parameters.MAX_TRACE_LENGTH -> Maximum trace length
+            Parameters.INITIAL_TIMESTAMP -> The first event is set with INITIAL_TIMESTAMP increased from 1970
+            Parameters.INITIAL_CASE_ID -> Numeric case id for the first trace
             Parameters.PETRI_SEMANTICS -> Petri net semantics to be used (default: petri_nets.semantics.ClassicSemantics())
     """
     if parameters is None:
@@ -145,10 +154,15 @@ def apply(net: PetriNet, initial_marking: Marking, final_marking: Marking = None
                                                xes_constants.DEFAULT_TIMESTAMP_KEY)
     no_traces = exec_utils.get_param_value(Parameters.NO_TRACES, parameters, 1000)
     max_trace_length = exec_utils.get_param_value(Parameters.MAX_TRACE_LENGTH, parameters, 1000)
+    initial_timestamp = exec_utils.get_param_value(Parameters.INITIAL_TIMESTAMP, parameters, 10000000)
+    initial_case_id = exec_utils.get_param_value(Parameters.INITIAL_CASE_ID, parameters, 0)
     return_visited_elements = exec_utils.get_param_value(Parameters.RETURN_VISITED_ELEMENTS, parameters, False)
     semantics = exec_utils.get_param_value(Parameters.PETRI_SEMANTICS, parameters, petri_net.semantics.ClassicSemantics())
 
-    return apply_playout(net, initial_marking, max_trace_length=max_trace_length, no_traces=no_traces,
+    return apply_playout(net, initial_marking, max_trace_length=max_trace_length,
+                         initial_timestamp=initial_timestamp,
+                         initial_case_id=initial_case_id,
+                         no_traces=no_traces,
                          case_id_key=case_id_key, activity_key=activity_key, timestamp_key=timestamp_key,
                          final_marking=final_marking, return_visited_elements=return_visited_elements,
                          semantics=semantics)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 cvxopt
 deprecation
-fastparquet
 graphviz
 intervaltree
 jsonpickle
@@ -9,9 +8,7 @@ matplotlib
 networkx
 numpy>=1.19.5
 pandas>=1.1.5
-pyarrow
 pydotplus
-pyemd
 pytz
 pyvis
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 cvxopt
 deprecation
+fastparquet
 graphviz
 intervaltree
 jsonpickle
@@ -8,7 +9,9 @@ matplotlib
 networkx
 numpy>=1.19.5
 pandas>=1.1.5
+pyarrow
 pydotplus
+pyemd
 pytz
 pyvis
 scipy

--- a/tests/execute_tests.py
+++ b/tests/execute_tests.py
@@ -40,6 +40,7 @@ if __name__ == "__main__":
     from tests.simplified_interface import SimplifiedInterfaceTest
     from tests.ocel_filtering_test import OcelFilteringTest
     from tests.ocel_discovery_test import OcelDiscoveryTest
+    from tests.simulation_test import SimulationTest
 
     ocel_filtering_test = OcelFilteringTest()
     ocel_discovery_test = OcelDiscoveryTest()
@@ -74,5 +75,6 @@ if __name__ == "__main__":
     woflan_test = WoflanTest()
     diagn_dataframe_test = DiagnDfConfChecking()
     simplified_test = SimplifiedInterfaceTest()
+    simulation_test = SimulationTest()
 
     unittest.main()

--- a/tests/simulation_test.py
+++ b/tests/simulation_test.py
@@ -1,0 +1,46 @@
+import os
+import unittest
+
+from pm4py.objects.petri_net.importer import importer as pnml_importer
+from pm4py.algo.simulation.playout.petri_net import algorithm as simulator
+from tests.constants import INPUT_DATA_DIR
+from datetime import datetime
+
+
+class SimulationTest(unittest.TestCase):
+    def test_simulate_petrinet(self):
+        net, im, fm = pnml_importer.apply(
+            os.path.join(INPUT_DATA_DIR, "running-example.pnml"))
+        number_of_traces = 10
+        eventlog = simulator.apply(net, im, fm, variant=simulator.Variants.BASIC_PLAYOUT,
+                                   parameters={
+                                       simulator.Variants.BASIC_PLAYOUT.value.Parameters.NO_TRACES: number_of_traces})
+        self.assertEqual(len(eventlog), number_of_traces)
+        case_id_default = 0
+        last_case_id = case_id_default + number_of_traces - 1
+        timestamp_default = 10000000
+        self.assertEqual(eventlog[0].attributes['concept:name'], str(case_id_default))
+        self.assertEqual(datetime.timestamp(eventlog[0][0]['time:timestamp']), timestamp_default)
+        self.assertEqual(eventlog[-1].attributes['concept:name'], str(last_case_id))
+
+    def test_simulate_petrinet_start_params(self):
+        net, im, fm = pnml_importer.apply(
+            os.path.join(INPUT_DATA_DIR, "running-example.pnml"))
+        number_of_traces = 10
+        timestamp = 50000000
+        case_id = 5
+        eventlog = simulator.apply(net, im, fm, variant=simulator.Variants.BASIC_PLAYOUT,
+                                   parameters={
+                                       simulator.Variants.BASIC_PLAYOUT.value.Parameters.NO_TRACES: number_of_traces,
+                                       simulator.Variants.BASIC_PLAYOUT.value.Parameters.INITIAL_TIMESTAMP:
+                                           timestamp,
+                                       simulator.Variants.BASIC_PLAYOUT.value.Parameters.INITIAL_CASE_ID: case_id})
+        self.assertEqual(len(eventlog), number_of_traces)
+        last_case_id = case_id + number_of_traces - 1
+        self.assertEqual(eventlog[0].attributes['concept:name'], str(case_id))
+        self.assertEqual(datetime.timestamp(eventlog[0][0]['time:timestamp']), timestamp)
+        self.assertEqual(eventlog[-1].attributes['concept:name'], str(last_case_id))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1) Included 2 new parameters for the BASIC PLAYOUT for Petri Nets:
initial_timestamp
	Increased timestamp from 1970 for the first event
initial_case_id
	Case id of the first event

These parameters can be set for defining the timestamp and the case id for the first event of the simulated log.

2) Included class SimulationTest with the unity tests for the new parameters and updated execute_tests.py to call the new class.

3) Updated requirements.txt
When I try to execute all the unity tests (python execute_tests.py) I received errors and I have to install the following libraries:

pip install -U sklearn
pip install -U pyemd
pip install -U pyarrow
pip install -U fastparquet