### PR TITLE
Inductive Miner Example log path fix

### DIFF
--- a/examples/inductive_miner.py
+++ b/examples/inductive_miner.py
@@ -39,7 +39,7 @@ def keep_one_trace_per_variant(log, parameters=None):
 
 
 def execute_script():
-    log_path = os.path.join("/Users/Julian/Documents/HiWi/PADS/EventLogs/BPI_Challenge_2012.xes")
+    log_path = os.path.join("..", "tests", "input_data", "running-example.xes")
     log = xes_import.apply(log_path)
     #log = keep_one_trace_per_variant(log)
     #log = log[15:30]


### PR DESCRIPTION
Changed os.path.join() for the `running-example.xes` used as reference for examples given in the folder `/examples`.

The previous file was located on the user's file system and not accessible nor permitted through licensing (BPI_Challenge_2012.xes could only be added to the used files if the source was referenced in the project). 

Old dataset available [here](https://data.4tu.nl/articles/dataset/BPI_Challenge_2012/12689204) and the [4TU General Terms of Use](https://doi.org/10.4121/resource:terms_of_use).