### PR TITLE
Update frequency.py to run in linear time

### DIFF
--- a/pm4py/streaming/algo/discovery/dfg/variants/frequency.py
+++ b/pm4py/streaming/algo/discovery/dfg/variants/frequency.py
@@ -127,18 +127,18 @@ class StreamingDfgDiscovery(StreamingAlgorithm):
         if self.case_id_key in event and self.activity_key in event:
             case = self.encode_str(event[self.case_id_key])
             activity = self.encode_str(event[self.activity_key])
-            if case not in self.case_dict.keys():
-                if activity not in self.start_activities.keys():
+            if case not in self.case_dict:
+                if activity not in self.start_activities:
                     self.start_activities[activity] = 1
                 else:
                     self.start_activities[activity] = int(self.start_activities[activity]) + 1
             else:
                 df = self.encode_tuple((self.case_dict[case], activity))
-                if df not in self.dfg.keys():
+                if df not in self.dfg:
                     self.dfg[df] = 1
                 else:
                     self.dfg[df] = int(self.dfg[df]) + 1
-            if activity not in self.activities.keys():
+            if activity not in self.activities:
                 self.activities[activity] = 1
             else:
                 self.activities[activity] = int(self.activities[activity]) + 1
@@ -161,10 +161,10 @@ class StreamingDfgDiscovery(StreamingAlgorithm):
         end_activities
             End activities
         """
-        dfg = {eval(x): int(self.dfg[x]) for x in self.dfg.keys()}
-        activities = {x: int(self.activities[x]) for x in self.activities.keys()}
-        start_activities = {x: int(self.start_activities[x]) for x in self.start_activities.keys()}
-        end_activities = dict(Counter(self.case_dict[x] for x in self.case_dict.keys()))
+        dfg = {eval(x): int(self.dfg[x]) for x in self.dfg()}
+        activities = {x: int(self.activities[x]) for x in self.activities()}
+        start_activities = {x: int(self.start_activities[x]) for x in self.start_activities()}
+        end_activities = dict(Counter(self.case_dict[x] for x in self.case_dict()))
         return dfg, activities, start_activities, end_activities
 
 


### PR DESCRIPTION
I analyzed some large event-streams (containing over 1M events and 30,000 cases) and observed a very high runtime for the program. While running the event stream simulation it showed that if more events are stored in the dictionary the operation gets significantly slower. This behavior indicates at least an linear runtime, e.g. O(n). But usually a Python dictionary has a search runtime of O(1). I found out that this is due to the implementation of the dictionary data structure in "pm4py.streaming.util.dictio.versions.thread_safe.py". The method "keys()" of thread_safe.py is responsible for the increased runtime . Especially the "case_dict" is a problem, since this strucuture grows quickly with new arriving cases. Particularly the statement "if case not in self.case_dict.keys()" is responsible for the increased runtime. To circumvent this issue it is possible to just use "if case not in self.case_dict".