### PR TITLE
Import `OptimizeResult` from the `scipy.optimize` namespace

### DIFF
--- a/pm4py/util/lp/variants/scipy_solver.py
+++ b/pm4py/util/lp/variants/scipy_solver.py
@@ -16,8 +16,7 @@
 '''
 
 import numpy as np
-from scipy.optimize import linprog
-from scipy.optimize.optimize import OptimizeResult
+from scipy.optimize import linprog, OptimizeResult
 from typing import Optional, Dict, Any, List
 from enum import Enum
 from pm4py.util import exec_utils


### PR DESCRIPTION
To avoid the warning: "DeprecationWarning: Please use `OptimizeResult` from the `scipy.optimize` namespace, the `scipy.optimize.optimize` namespace is deprecated."