### PR TITLE
fixed a bug where the _get_leaves() function called by an ProcessTree…

### DIFF
--- a/pm4py/objects/process_tree/obj.py
+++ b/pm4py/objects/process_tree/obj.py
@@ -196,7 +196,7 @@ class ProcessTree(object):
     def _get_leaves(self):
         root = self._get_root()
         leaves = root
-        if root._get_children != list():
+        if root._get_children() != list():
             leaves = root._get_children()
             change_of_leaves = True
             while change_of_leaves:


### PR DESCRIPTION
… consisting of only one node, would return an empty list instead of the node itself.
The reason was missing Brackets in line 199