### PR TITLE
Export of event logs

### DIFF
--- a/pm4py/objects/log/exporter/xes/variants/line_by_line.py
+++ b/pm4py/objects/log/exporter/xes/variants/line_by_line.py
@@ -15,9 +15,11 @@
     along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
 '''
 import gzip
+import numbers
 import pkgutil
 from enum import Enum
 from io import BytesIO
+from math import isnan
 
 from pm4py.objects.log.util import xes as xes_util
 from pm4py.util import exec_utils, constants
@@ -187,6 +189,8 @@ def export_trace_line_by_line(trace, fp_obj, encoding):
     for event in trace:
         fp_obj.write((get_tab_indent(2) + "<event>\n").encode(encoding))
         for attr_name, attr_value in event.items():
+            if isinstance(attr_value, numbers.Number) and isnan(attr_value):
+                continue
             fp_obj.write(export_attribute(attr_name, attr_value, 3).encode(encoding))
         fp_obj.write((get_tab_indent(2) + "</event>\n").encode(encoding))
     fp_obj.write((get_tab_indent(1) + "</trace>\n").encode(encoding))


### PR DESCRIPTION
For some event logs using `pm4py.write_xes()` leads to an .xes file that is different from the original one (when using the line_by_line variant) . If there are events with a different amount of attributes in the log, attributes are added to the events with less attributes. 
For example an event looked like this in the original .xes file

   ```
<event>
			<string key="org:resource" value="System" />
			<date key="time:timestamp" value="1970-01-02T11:23:00+00:00" />
			<string key="concept:name" value="Register" />
			<string key="lifecycle:transition" value="complete" />
   </event>
```

might look like this after using `pm4py.write_xes()`

```
   <event>
			<string key="org:resource" value="System" />
			<date key="time:timestamp" value="1970-01-02T11:23:00+00:00" />
			<string key="concept:name" value="Register" />
			<string key="lifecycle:transition" value="complete" />
			<float key="defectType" value="nan" />
			<float key="phoneType" value="nan" />
			<float key="numberRepairs" value="nan" />
			<float key="defectFixed" value="nan" />
   </event>
```

This leads to an exception when trying import the resulting .xes file in ProM:

<img width="450" alt="ProM_error_message" src="https://user-images.githubusercontent.com/23171789/232542052-19e3fe0b-0829-400b-a6c1-e60a576e0593.PNG">

In this pull request the attributes of type number and the value "nan" (which are the ones who cause the exception) get excluded from the exported event log.
