### PR TITLE
Fix alignment-based replay fitness multiprocessing

### DIFF
--- a/pm4py/algo/evaluation/replay_fitness/algorithm.py
+++ b/pm4py/algo/evaluation/replay_fitness/algorithm.py
@@ -62,6 +62,8 @@ def apply(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, initial_marki
         Chosen variant:
             - Variants.ALIGNMENT_BASED
             - Variants.TOKEN_BASED
+    align_variant
+        Alignments variant (for alignment-based replay)
 
     Returns
     ----------

--- a/pm4py/algo/evaluation/replay_fitness/algorithm.py
+++ b/pm4py/algo/evaluation/replay_fitness/algorithm.py
@@ -41,7 +41,7 @@ TOKEN_BASED = Variants.TOKEN_BASED
 VERSIONS = {ALIGNMENT_BASED, TOKEN_BASED}
 
 
-def apply(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, initial_marking: Marking, final_marking: Marking, parameters: Optional[Dict[Union[str, Parameters], Any]] = None, variant=None) -> Dict[str, Any]:
+def apply(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, initial_marking: Marking, final_marking: Marking, parameters: Optional[Dict[Union[str, Parameters], Any]] = None, variant=None, align_variant=None) -> Dict[str, Any]:
     """
     Apply fitness evaluation starting from an event log and a marked Petri net,
     by using one of the replay techniques provided by PM4Py
@@ -89,8 +89,8 @@ def apply(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, initial_marki
                                                      initial_marking, final_marking, parameters=parameters)
     else:
         # execute the alignments based variant, with the specification of the alignments variant
-        align_variant = exec_utils.get_param_value(Parameters.ALIGN_VARIANT, parameters,
-                                                   alignments.petri_net.algorithm.DEFAULT_VARIANT)
+        if align_variant is None:
+            align_variant = alignments.petri_net.algorithm.DEFAULT_VARIANT
         return exec_utils.get_variant(variant).apply(log,
                                                      petri_net,
                                                      initial_marking, final_marking, align_variant=align_variant,

--- a/pm4py/conformance.py
+++ b/pm4py/conformance.py
@@ -261,6 +261,7 @@ def fitness_alignments(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, 
     :param activity_key: attribute to be used for the activity
     :param timestamp_key: attribute to be used for the timestamp
     :param case_id_key: attribute to be used as case identifier
+    :param variant_str: variant specification
     :rtype: ``Dict[str, float]``
 
     .. code-block:: python3

--- a/pm4py/conformance.py
+++ b/pm4py/conformance.py
@@ -236,7 +236,7 @@ def fitness_token_based_replay(log: Union[EventLog, pd.DataFrame], petri_net: Pe
     return result
 
 
-def fitness_alignments(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, initial_marking: Marking, final_marking: Marking, multi_processing: bool = constants.ENABLE_MULTIPROCESSING_DEFAULT, activity_key: str = "concept:name", timestamp_key: str = "time:timestamp", case_id_key: str = "case:concept:name") -> \
+def fitness_alignments(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, initial_marking: Marking, final_marking: Marking, multi_processing: bool = constants.ENABLE_MULTIPROCESSING_DEFAULT, activity_key: str = "concept:name", timestamp_key: str = "time:timestamp", case_id_key: str = "case:concept:name", variant_str : Optional[str] = None) -> \
         Dict[str, float]:
     """
     Calculates the fitness using alignments
@@ -280,7 +280,7 @@ def fitness_alignments(log: Union[EventLog, pd.DataFrame], petri_net: PetriNet, 
     parameters = get_properties(log, activity_key=activity_key, timestamp_key=timestamp_key, case_id_key=case_id_key)
     parameters["multiprocessing"] = multi_processing
     result = replay_fitness.apply(log, petri_net, initial_marking, final_marking,
-                                variant=replay_fitness.Variants.ALIGNMENT_BASED, parameters=parameters)
+                                  variant=replay_fitness.Variants.ALIGNMENT_BASED, align_variant=variant_str, parameters=parameters)
 
     return result
 


### PR DESCRIPTION
**Problem**
Commit 70198faa1b674c3a4e4351ff251a9af504e16a4e introduced a `variant_str` argument in `pm4py.conformance.conformance_diagnostics_alignments()`, allowing to choose the alignments algorithm variant. To facilitate this,  `pm4py.algo.conformance.alignments.petri_net.algorithm.apply_multiprocessing()` was modified to pass `str(variant)` to scheduled futures. `str(variant)` returns a name when `variant` is an `Enum` member. However, when `variant` is a value of an `Enum` member, `str(variant)` returns a string containing an object reference. This breaks `pm4py.conformance.fitness_alignments()` when multiprocessing is enabled.

**Steps to reproduce**
Call `pm4py.conformance.fitness_alignments()` with `multi_processing=True`.

**Solution**
Add `variant_str` argument to `pm4py.conformance.fitness_alignments()` and pass it down to `pm4py.evaluation.replay_fitness.algorithm`. This has the added benefit of unifying the API between `pm4py.conformance.conformance_diagnostics_alignments()` and  `pm4py.conformance.fitness_alignments()`.