### PR TITLE
Adapt openai calls to v1 migration

### DIFF
--- a/pm4py/algo/querying/llm/connectors/openai.py
+++ b/pm4py/algo/querying/llm/connectors/openai.py
@@ -35,9 +35,9 @@ def apply(query: str, parameters: Optional[Dict[Any, Any]] = None) -> str:
 
     import openai
 
-    openai.api_key = api_key
+    client = openai.OpenAI(api_key=api_key)
 
     message = {"role": "user", "content": query}
 
-    response = openai.ChatCompletion.create(model=model, messages=[message])
+    response = client.chat.completions.create(model=model, messages=[message])
     return response["choices"][0]["message"]["content"]


### PR DESCRIPTION
Openai python API has been updated the 6th of november 2023 when the [v1 migration](https://github.com/openai/openai-python/discussions/742) guide has been published.
This PR just updates the openai connector to the last way to query the Openai API.