### PR TITLE
Added support for XES composite list attributes

### DIFF
--- a/pm4py/objects/log/exporter/xes/variants/line_by_line.py
+++ b/pm4py/objects/log/exporter/xes/variants/line_by_line.py
@@ -1,4 +1,4 @@
-'''
+"""
     This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
 
     PM4Py is free software: you can redistribute it and/or modify
@@ -13,7 +13,8 @@
 
     You should have received a copy of the GNU General Public License
     along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
-'''
+"""
+
 import gzip
 import importlib.util
 from enum import Enum
@@ -41,7 +42,7 @@ __TYPE_CORRESPONDENCE = {
     "dict": xes_util.TAG_LIST,
     "numpy.int64": xes_util.TAG_INT,
     "numpy.float64": xes_util.TAG_FLOAT,
-    "numpy.datetime64": xes_util.TAG_DATE
+    "numpy.datetime64": xes_util.TAG_DATE,
 }
 # if a type is not found in the previous list, then default to string
 __DEFAULT_TYPE = xes_util.TAG_STRING
@@ -139,19 +140,29 @@ def export_attribute(attr_name, attr_value, indent_level):
         String representing the content of the attribute
     """
     ret = []
+
     if attr_name is not None and attr_value is not None:
         attr_type = __get_xes_attr_type(attr_name, type(attr_value).__name__)
         if not attr_type == xes_util.TAG_LIST:
             attr_value = __get_xes_attr_value(attr_value, attr_type)
-            ret.append(get_tab_indent(
-                indent_level) + "<%s key=%s value=%s />\n" % (attr_type, escape(attr_name), escape(attr_value)))
+            ret.append(
+                get_tab_indent(indent_level)
+                + "<%s key=%s value=%s />\n"
+                % (attr_type, escape(attr_name), escape(attr_value))
+            )
         else:
             if attr_value[xes_util.KEY_VALUE] is None:
                 # list
-                ret.append(get_tab_indent(indent_level) + "<list key=%s>\n" % (escape(attr_name)))
+                ret.append(
+                    get_tab_indent(indent_level)
+                    + "<list key=%s>\n" % (escape(attr_name))
+                )
                 ret.append(get_tab_indent(indent_level + 1) + "<values>\n")
                 for subattr in attr_value[xes_util.KEY_CHILDREN]:
-                    ret.append(export_attribute(subattr[0], subattr[1], indent_level + 2))
+                    ret.append(
+                        export_attribute(subattr[0], subattr[1], indent_level + 2)
+                    )
+
                 ret.append(get_tab_indent(indent_level + 1) + "</values>\n")
                 ret.append(get_tab_indent(indent_level) + "</list>\n")
             else:
@@ -159,11 +170,18 @@ def export_attribute(attr_name, attr_value, indent_level):
                 this_value = attr_value[xes_util.KEY_VALUE]
                 this_type = __get_xes_attr_type(attr_name, type(this_value).__name__)
                 this_value = __get_xes_attr_value(this_value, this_type)
-                ret.append(get_tab_indent(
-                    indent_level) + "<%s key=%s value=%s>\n" % (this_type, escape(attr_name), escape(this_value)))
-                for subattr_name, subattr_value in attr_value[xes_util.KEY_CHILDREN].items():
-                    ret.append(export_attribute(subattr_name, subattr_value, indent_level + 1))
-                ret.append("</%s>\n" % this_type)
+                ret.append(
+                    get_tab_indent(indent_level)
+                    + "<%s key=%s value=%s>\n"
+                    % (this_type, escape(attr_name), escape(this_value))
+                )
+                for subattr_name, subattr_value in attr_value[
+                    xes_util.KEY_CHILDREN
+                ].items():
+                    ret.append(
+                        export_attribute(subattr_name, subattr_value, indent_level + 1)
+                    )
+                ret.append(get_tab_indent(indent_level) + "</%s>\n" % this_type)
     return "".join(ret)
 
 
@@ -211,26 +229,62 @@ def export_log_line_by_line(log, fp_obj, encoding, parameters=None):
     if parameters is None:
         parameters = {}
 
-    show_progress_bar = exec_utils.get_param_value(Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR)
+    show_progress_bar = exec_utils.get_param_value(
+        Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR
+    )
 
     progress = None
     if importlib.util.find_spec("tqdm") and show_progress_bar:
         from tqdm.auto import tqdm
+
         progress = tqdm(total=len(log), desc="exporting log, completed traces :: ")
 
-    fp_obj.write(("<?xml version=\"1.0\" encoding=\"" + encoding + "\" ?>\n").encode(
-        encoding))
-    fp_obj.write(("<log "+xes_util.TAG_VERSION+"=\""+xes_util.VALUE_XES_VERSION+"\" "+xes_util.TAG_FEATURES+"=\""+xes_util.VALUE_XES_FEATURES+"\" "+xes_util.TAG_XMLNS+"=\""+xes_util.VALUE_XMLNS+"\">\n").encode(encoding))
+    fp_obj.write(
+        ('<?xml version="1.0" encoding="' + encoding + '" ?>\n').encode(encoding)
+    )
+    fp_obj.write(
+        (
+            "<log "
+            + xes_util.TAG_VERSION
+            + '="'
+            + xes_util.VALUE_XES_VERSION
+            + '" '
+            + xes_util.TAG_FEATURES
+            + '="'
+            + xes_util.VALUE_XES_FEATURES
+            + '" '
+            + xes_util.TAG_XMLNS
+            + '="'
+            + xes_util.VALUE_XMLNS
+            + '">\n'
+        ).encode(encoding)
+    )
     for ext_name, ext_value in log.extensions.items():
-        fp_obj.write((get_tab_indent(1) + "<extension name=\"%s\" prefix=\"%s\" uri=\"%s\" />\n" % (
-            ext_name, ext_value[xes_util.KEY_PREFIX], ext_value[xes_util.KEY_URI])).encode(encoding))
+        fp_obj.write(
+            (
+                get_tab_indent(1)
+                + '<extension name="%s" prefix="%s" uri="%s" />\n'
+                % (
+                    ext_name,
+                    ext_value[xes_util.KEY_PREFIX],
+                    ext_value[xes_util.KEY_URI],
+                )
+            ).encode(encoding)
+        )
     for clas_name, clas_attributes in log.classifiers.items():
-        fp_obj.write((get_tab_indent(1) + "<classifier name=\"%s\" keys=\"%s\" />\n" % (
-            clas_name, " ".join(clas_attributes))).encode(encoding))
+        fp_obj.write(
+            (
+                get_tab_indent(1)
+                + '<classifier name="%s" keys="%s" />\n'
+                % (clas_name, " ".join(clas_attributes))
+            ).encode(encoding)
+        )
     for attr_name, attr_value in log.attributes.items():
         fp_obj.write(export_attribute(attr_name, attr_value, 1).encode(encoding))
     for scope in log.omni_present:
-        fp_obj.write((get_tab_indent(1) + "<global scope=\"%s\">\n" % (scope)).encode(encoding))
+        fp_obj.write(
+            (get_tab_indent(1) + '<global scope="%s">\n' % (scope)).encode(encoding)
+        )
         for attr_name, attr_value in log.omni_present[scope].items():
             fp_obj.write(export_attribute(attr_name, attr_value, 2).encode(encoding))
         fp_obj.write((get_tab_indent(1) + "</global>\n").encode(encoding))
@@ -263,8 +317,12 @@ def apply(log, output_file_path, parameters=None):
     if parameters is None:
         parameters = {}
 
-    encoding = exec_utils.get_param_value(Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING)
-    compress = exec_utils.get_param_value(Parameters.COMPRESS, parameters, output_file_path.lower().endswith(".gz"))
+    encoding = exec_utils.get_param_value(
+        Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING
+    )
+    compress = exec_utils.get_param_value(
+        Parameters.COMPRESS, parameters, output_file_path.lower().endswith(".gz")
+    )
 
     if compress:
         if not output_file_path.lower().endswith(".gz"):
@@ -297,7 +355,9 @@ def export_log_as_string(log, parameters=None):
     if parameters is None:
         parameters = {}
 
-    encoding = exec_utils.get_param_value(Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING)
+    encoding = exec_utils.get_param_value(
+        Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING
+    )
     compress = exec_utils.get_param_value(Parameters.COMPRESS, parameters, False)
 
     b = BytesIO()

--- a/pm4py/objects/log/importer/xes/variants/iterparse.py
+++ b/pm4py/objects/log/importer/xes/variants/iterparse.py
@@ -1,4 +1,4 @@
-'''
+"""
     This file is part of PM4Py (More Info: https://pm4py.fit.fraunhofer.de).
 
     PM4Py is free software: you can redistribute it and/or modify
@@ -13,7 +13,8 @@
 
     You should have received a copy of the GNU General Public License
     along with PM4Py.  If not, see <https://www.gnu.org/licenses/>.
-'''
+"""
+
 import gzip
 import logging
 import importlib.util
@@ -39,8 +40,8 @@ class Parameters(Enum):
 
 
 # ITERPARSE EVENTS
-_EVENT_END = 'end'
-_EVENT_START = 'start'
+_EVENT_END = "end"
+_EVENT_START = "start"
 
 
 def count_traces(context):
@@ -90,17 +91,27 @@ def import_from_context(context, num_traces, parameters=None):
     if parameters is None:
         parameters = {}
 
-    max_no_traces_to_import = exec_utils.get_param_value(Parameters.MAX_TRACES, parameters, sys.maxsize)
-    timestamp_sort = exec_utils.get_param_value(Parameters.TIMESTAMP_SORT, parameters, False)
-    timestamp_key = exec_utils.get_param_value(Parameters.TIMESTAMP_KEY, parameters,
-                                               xes_constants.DEFAULT_TIMESTAMP_KEY)
-    reverse_sort = exec_utils.get_param_value(Parameters.REVERSE_SORT, parameters, False)
-    show_progress_bar = exec_utils.get_param_value(Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR)
+    max_no_traces_to_import = exec_utils.get_param_value(
+        Parameters.MAX_TRACES, parameters, sys.maxsize
+    )
+    timestamp_sort = exec_utils.get_param_value(
+        Parameters.TIMESTAMP_SORT, parameters, False
+    )
+    timestamp_key = exec_utils.get_param_value(
+        Parameters.TIMESTAMP_KEY, parameters, xes_constants.DEFAULT_TIMESTAMP_KEY
+    )
+    reverse_sort = exec_utils.get_param_value(
+        Parameters.REVERSE_SORT, parameters, False
+    )
+    show_progress_bar = exec_utils.get_param_value(
+        Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR
+    )
 
     date_parser = dt_parser.get()
     progress = None
     if importlib.util.find_spec("tqdm") and show_progress_bar:
         from tqdm.auto import tqdm
+
         progress = tqdm(total=num_traces, desc="parsing log, completed traces :: ")
 
     log = None
@@ -115,23 +126,36 @@ def import_from_context(context, num_traces, parameters=None):
 
             if elem.tag.endswith(xes_constants.TAG_STRING):
                 if parent is not None:
-                    tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY),
-                                             elem.get(xes_constants.KEY_VALUE), tree)
+                    tree = __parse_attribute(
+                        elem,
+                        parent,
+                        elem.get(xes_constants.KEY_KEY),
+                        elem.get(xes_constants.KEY_VALUE),
+                        tree,
+                    )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_DATE):
                 try:
                     dt = date_parser.apply(elem.get(xes_constants.KEY_VALUE))
-                    tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY), dt, tree)
+                    tree = __parse_attribute(
+                        elem, parent, elem.get(xes_constants.KEY_KEY), dt, tree
+                    )
                 except TypeError:
-                    logging.info("failed to parse date: " + str(elem.get(xes_constants.KEY_VALUE)))
+                    logging.info(
+                        "failed to parse date: "
+                        + str(elem.get(xes_constants.KEY_VALUE))
+                    )
                 except ValueError:
-                    logging.info("failed to parse date: " + str(elem.get(xes_constants.KEY_VALUE)))
+                    logging.info(
+                        "failed to parse date: "
+                        + str(elem.get(xes_constants.KEY_VALUE))
+                    )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_EVENT):
                 if event is not None:
-                    raise SyntaxError('file contains <event> in another <event> tag')
+                    raise SyntaxError("file contains <event> in another <event> tag")
                 event = Event()
                 tree[elem] = event
                 continue
@@ -140,7 +164,7 @@ def import_from_context(context, num_traces, parameters=None):
                 if len(log) >= max_no_traces_to_import:
                     break
                 if trace is not None:
-                    raise SyntaxError('file contains <trace> in another <trace> tag')
+                    raise SyntaxError("file contains <trace> in another <trace> tag")
                 trace = Trace()
                 tree[elem] = trace.attributes
                 continue
@@ -149,18 +173,28 @@ def import_from_context(context, num_traces, parameters=None):
                 if parent is not None:
                     try:
                         val = float(elem.get(xes_constants.KEY_VALUE))
-                        tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY), val, tree)
+                        tree = __parse_attribute(
+                            elem, parent, elem.get(xes_constants.KEY_KEY), val, tree
+                        )
                     except ValueError:
-                        logging.info("failed to parse float: " + str(elem.get(xes_constants.KEY_VALUE)))
+                        logging.info(
+                            "failed to parse float: "
+                            + str(elem.get(xes_constants.KEY_VALUE))
+                        )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_INT):
                 if parent is not None:
                     try:
                         val = int(elem.get(xes_constants.KEY_VALUE))
-                        tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY), val, tree)
+                        tree = __parse_attribute(
+                            elem, parent, elem.get(xes_constants.KEY_KEY), val, tree
+                        )
                     except ValueError:
-                        logging.info("failed to parse int: " + str(elem.get(xes_constants.KEY_VALUE)))
+                        logging.info(
+                            "failed to parse int: "
+                            + str(elem.get(xes_constants.KEY_VALUE))
+                        )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_BOOLEAN):
@@ -170,36 +204,52 @@ def import_from_context(context, num_traces, parameters=None):
                         val = False
                         if str(val0).lower() == "true":
                             val = True
-                        tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY), val, tree)
+                        tree = __parse_attribute(
+                            elem, parent, elem.get(xes_constants.KEY_KEY), val, tree
+                        )
                     except ValueError:
-                        logging.info("failed to parse boolean: " + str(elem.get(xes_constants.KEY_VALUE)))
+                        logging.info(
+                            "failed to parse boolean: "
+                            + str(elem.get(xes_constants.KEY_VALUE))
+                        )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_LIST):
                 if parent is not None:
                     # lists have no value, hence we put None as a value
-                    tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY), None, tree)
+                    tree = __parse_attribute(
+                        elem, parent, elem.get(xes_constants.KEY_KEY), None, tree
+                    )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_ID):
                 if parent is not None:
-                    tree = __parse_attribute(elem, parent, elem.get(xes_constants.KEY_KEY),
-                                             elem.get(xes_constants.KEY_VALUE), tree)
+                    tree = __parse_attribute(
+                        elem,
+                        parent,
+                        elem.get(xes_constants.KEY_KEY),
+                        elem.get(xes_constants.KEY_VALUE),
+                        tree,
+                    )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_EXTENSION):
                 if log is None:
-                    raise SyntaxError('extension found outside of <log> tag')
-                if elem.get(xes_constants.KEY_NAME) is not None and elem.get(
-                        xes_constants.KEY_PREFIX) is not None and elem.get(xes_constants.KEY_URI) is not None:
+                    raise SyntaxError("extension found outside of <log> tag")
+                if (
+                    elem.get(xes_constants.KEY_NAME) is not None
+                    and elem.get(xes_constants.KEY_PREFIX) is not None
+                    and elem.get(xes_constants.KEY_URI) is not None
+                ):
                     log.extensions[elem.get(xes_constants.KEY_NAME)] = {
                         xes_constants.KEY_PREFIX: elem.get(xes_constants.KEY_PREFIX),
-                        xes_constants.KEY_URI: elem.get(xes_constants.KEY_URI)}
+                        xes_constants.KEY_URI: elem.get(xes_constants.KEY_URI),
+                    }
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_GLOBAL):
                 if log is None:
-                    raise SyntaxError('global found outside of <log> tag')
+                    raise SyntaxError("global found outside of <log> tag")
                 if elem.get(xes_constants.KEY_SCOPE) is not None:
                     log.omni_present[elem.get(xes_constants.KEY_SCOPE)] = {}
                     tree[elem] = log.omni_present[elem.get(xes_constants.KEY_SCOPE)]
@@ -207,19 +257,22 @@ def import_from_context(context, num_traces, parameters=None):
 
             elif elem.tag.endswith(xes_constants.TAG_CLASSIFIER):
                 if log is None:
-                    raise SyntaxError('classifier found outside of <log> tag')
+                    raise SyntaxError("classifier found outside of <log> tag")
                 if elem.get(xes_constants.KEY_KEYS) is not None:
                     classifier_value = elem.get(xes_constants.KEY_KEYS)
                     if "'" in classifier_value:
-                        log.classifiers[elem.get(xes_constants.KEY_NAME)] = [x for x in classifier_value.split("'")
-                                                                             if x.strip()]
+                        log.classifiers[elem.get(xes_constants.KEY_NAME)] = [
+                            x for x in classifier_value.split("'") if x.strip()
+                        ]
                     else:
-                        log.classifiers[elem.get(xes_constants.KEY_NAME)] = classifier_value.split()
+                        log.classifiers[elem.get(xes_constants.KEY_NAME)] = (
+                            classifier_value.split()
+                        )
                 continue
 
             elif elem.tag.endswith(xes_constants.TAG_LOG):
                 if log is not None:
-                    raise SyntaxError('file contains > 1 <log> tags')
+                    raise SyntaxError("file contains > 1 <log> tags")
                 log = EventLog()
                 tree[elem] = log.attributes
                 continue
@@ -258,19 +311,33 @@ def import_from_context(context, num_traces, parameters=None):
     del context, progress
 
     if timestamp_sort:
-        log = sorting.sort_timestamp(log, timestamp_key=timestamp_key, reverse_sort=reverse_sort)
+        log = sorting.sort_timestamp(
+            log, timestamp_key=timestamp_key, reverse_sort=reverse_sort
+        )
 
     # sets the activity key as default classifier in the log's properties
-    log.properties[constants.PARAMETER_CONSTANT_ACTIVITY_KEY] = xes_constants.DEFAULT_NAME_KEY
-    log.properties[constants.PARAMETER_CONSTANT_ATTRIBUTE_KEY] = xes_constants.DEFAULT_NAME_KEY
+    log.properties[constants.PARAMETER_CONSTANT_ACTIVITY_KEY] = (
+        xes_constants.DEFAULT_NAME_KEY
+    )
+    log.properties[constants.PARAMETER_CONSTANT_ATTRIBUTE_KEY] = (
+        xes_constants.DEFAULT_NAME_KEY
+    )
     # sets the default timestamp key
-    log.properties[constants.PARAMETER_CONSTANT_TIMESTAMP_KEY] = xes_constants.DEFAULT_TIMESTAMP_KEY
+    log.properties[constants.PARAMETER_CONSTANT_TIMESTAMP_KEY] = (
+        xes_constants.DEFAULT_TIMESTAMP_KEY
+    )
     # sets the default resource key
-    log.properties[constants.PARAMETER_CONSTANT_RESOURCE_KEY] = xes_constants.DEFAULT_RESOURCE_KEY
+    log.properties[constants.PARAMETER_CONSTANT_RESOURCE_KEY] = (
+        xes_constants.DEFAULT_RESOURCE_KEY
+    )
     # sets the default transition key
-    log.properties[constants.PARAMETER_CONSTANT_TRANSITION_KEY] = xes_constants.DEFAULT_TRANSITION_KEY
+    log.properties[constants.PARAMETER_CONSTANT_TRANSITION_KEY] = (
+        xes_constants.DEFAULT_TRANSITION_KEY
+    )
     # sets the default group key
-    log.properties[constants.PARAMETER_CONSTANT_GROUP_KEY] = xes_constants.DEFAULT_GROUP_KEY
+    log.properties[constants.PARAMETER_CONSTANT_GROUP_KEY] = (
+        xes_constants.DEFAULT_GROUP_KEY
+    )
 
     return log
 
@@ -327,8 +394,12 @@ def import_log(filename, parameters=None):
     if parameters is None:
         parameters = {}
 
-    encoding = exec_utils.get_param_value(Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING)
-    show_progress_bar = exec_utils.get_param_value(Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR)
+    encoding = exec_utils.get_param_value(
+        Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING
+    )
+    show_progress_bar = exec_utils.get_param_value(
+        Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR
+    )
     is_compressed = filename.lower().endswith(".gz")
 
     if importlib.util.find_spec("tqdm") and show_progress_bar:
@@ -336,7 +407,9 @@ def import_log(filename, parameters=None):
             f = gzip.open(filename, "rb")
         else:
             f = open(filename, "rb")
-        context = etree.iterparse(f, events=[_EVENT_START, _EVENT_END], encoding=encoding)
+        context = etree.iterparse(
+            f, events=[_EVENT_START, _EVENT_END], encoding=encoding
+        )
         num_traces = count_traces(context)
     else:
         # avoid the iteration to calculate the number of traces is "tqdm" is not used
@@ -381,9 +454,15 @@ def import_from_string(log_string, parameters=None):
     if parameters is None:
         parameters = {}
 
-    encoding = exec_utils.get_param_value(Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING)
-    show_progress_bar = exec_utils.get_param_value(Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR)
-    decompress_serialization = exec_utils.get_param_value(Parameters.DECOMPRESS_SERIALIZATION, parameters, False)
+    encoding = exec_utils.get_param_value(
+        Parameters.ENCODING, parameters, constants.DEFAULT_ENCODING
+    )
+    show_progress_bar = exec_utils.get_param_value(
+        Parameters.SHOW_PROGRESS_BAR, parameters, constants.SHOW_PROGRESS_BAR
+    )
+    decompress_serialization = exec_utils.get_param_value(
+        Parameters.DECOMPRESS_SERIALIZATION, parameters, False
+    )
 
     if type(log_string) is str:
         log_string = log_string.encode(constants.DEFAULT_ENCODING)
@@ -395,7 +474,9 @@ def import_from_string(log_string, parameters=None):
             s = gzip.GzipFile(fileobj=b, mode="rb")
         else:
             s = b
-        context = etree.iterparse(s, events=[_EVENT_START, _EVENT_END], encoding=encoding)
+        context = etree.iterparse(
+            s, events=[_EVENT_START, _EVENT_END], encoding=encoding
+        )
         num_traces = count_traces(context)
     else:
         # avoid the iteration to calculate the number of traces is "tqdm" is not used
@@ -414,6 +495,7 @@ def import_from_string(log_string, parameters=None):
 
 def __parse_attribute(elem, store, key, value, tree):
     if len(elem.getchildren()) == 0:
+        # elementary attribute
         if type(store) is list:
             # changes to the store of lists: not dictionaries anymore
             # but pairs of key-values.
@@ -422,10 +504,39 @@ def __parse_attribute(elem, store, key, value, tree):
             store[key] = value
     else:
         if elem.getchildren()[0].tag.endswith(xes_constants.TAG_VALUES):
-            store[key] = {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: list()}
-            tree[elem] = store[key][xes_constants.KEY_CHILDREN]
-            tree[elem.getchildren()[0]] = tree[elem]
+            if isinstance(store, list):
+                store.append(
+                    (
+                        key,
+                        {
+                            xes_constants.KEY_VALUE: value,
+                            xes_constants.KEY_CHILDREN: list(),
+                        },
+                    )
+                )
+                tree[elem] = store[-1][1][xes_constants.KEY_CHILDREN]
+                tree[elem.getchildren()[0]] = tree[elem]
+
+            else:
+                store[key] = {
+                    xes_constants.KEY_VALUE: value,
+                    xes_constants.KEY_CHILDREN: list(),
+                }
+                tree[elem] = store[key][xes_constants.KEY_CHILDREN]
+                tree[elem.getchildren()[0]] = tree[elem]
+
         else:
-            store[key] = {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: dict()}
-            tree[elem] = store[key][xes_constants.KEY_CHILDREN]
+            composite_att = {
+                xes_constants.KEY_VALUE: value,
+                xes_constants.KEY_CHILDREN: dict(),
+            }
+
+            if isinstance(store, list):
+                store.append((key, composite_att))
+                tree[elem] = store[-1][1][xes_constants.KEY_CHILDREN]
+
+            else:
+                store[key] = composite_att
+                tree[elem] = store[key][xes_constants.KEY_CHILDREN]
+
     return tree

--- a/tests/execute_tests.py
+++ b/tests/execute_tests.py
@@ -14,14 +14,44 @@ pm4py.util.constants.SHOW_EVENT_LOG_DEPRECATION = False
 pm4py.util.constants.SHOW_INTERNAL_WARNINGS = False
 # pm4py.util.constants.DEFAULT_TIMESTAMP_PARSE_FORMAT = None
 
-enabled_tests = ["SimplifiedInterfaceTest", "SimplifiedInterface2Test", "DocTests", "RoleDetectionTest",
-                 "PassedTimeTest", "Pm4pyImportPackageTest", "XesImportExportTest", "CsvImportExportTest",
-                 "OtherPartsTests", "AlphaMinerTest", "InductiveMinerTest", "InductiveMinerTreeTest",
-                 "AlignmentTest", "DfgTests", "SnaTests", "PetriImportExportTest", "BPMNTests", "ETCTest",
-                 "DiagnDfConfChecking", "ProcessModelEvaluationTests", "DecisionTreeTest", "GraphsForming",
-                 "HeuMinerTest", "MainFactoriesTest", "AlgorithmTest", "LogFilteringTest",
-                 "DataframePrefilteringTest", "StatisticsLogTest", "StatisticsDfTest", "TransitionSystemTest",
-                 "ImpExpFromString", "WoflanTest", "OcelFilteringTest", "OcelDiscoveryTest", "LlmTest"]
+enabled_tests = [
+    "SimplifiedInterfaceTest",
+    "SimplifiedInterface2Test",
+    "DocTests",
+    "RoleDetectionTest",
+    "PassedTimeTest",
+    "Pm4pyImportPackageTest",
+    "XesImportExportTest",
+    "CsvImportExportTest",
+    "OtherPartsTests",
+    "AlphaMinerTest",
+    "InductiveMinerTest",
+    "InductiveMinerTreeTest",
+    "AlignmentTest",
+    "DfgTests",
+    "SnaTests",
+    "PetriImportExportTest",
+    "BPMNTests",
+    "ETCTest",
+    "DiagnDfConfChecking",
+    "ProcessModelEvaluationTests",
+    "DecisionTreeTest",
+    "GraphsForming",
+    "HeuMinerTest",
+    "MainFactoriesTest",
+    "AlgorithmTest",
+    "LogFilteringTest",
+    "DataframePrefilteringTest",
+    "StatisticsLogTest",
+    "StatisticsDfTest",
+    "TransitionSystemTest",
+    "ImpExpFromString",
+    "WoflanTest",
+    "OcelFilteringTest",
+    "OcelDiscoveryTest",
+    "LlmTest",
+    "XesCompositeAttTest",
+]
 
 loader = unittest.TestLoader()
 suite = unittest.TestSuite()
@@ -200,6 +230,11 @@ if "LlmTest" in enabled_tests:
     from tests.llm_test import LlmTest
 
     suite.addTests(loader.loadTestsFromTestCase(LlmTest))
+
+if "XesCompositeAttTest" in enabled_tests:
+    from tests.xes_composite_att_test import XesCompositeListAttributesTest
+
+    suite.addTests(loader.loadTestsFromTestCase(XesCompositeListAttributesTest))
 
 
 def main():

--- a/tests/input_data/composite_list_attributes.xes
+++ b/tests/input_data/composite_list_attributes.xes
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log xes.version="1849-2016" xes.features="nested-attributes" xmlns="http://www.xes-standard.org/">
+    <string key="Description" value="Minimal XES composite list attributes log."/>
+    <trace>
+        <event>
+            <list key="composite:list" >
+                <values>
+                    <string key="composite:list:elementary:string:1" value="example:string:value:1" />
+                    <string key="" value="">
+                        <string key="composite:string" value="composite:string:value:1" />
+                    </string>
+                    <string key="composite:list:elementary:string:2" value="example:string:value:2" />
+                    <list key="composite:composite:list">
+                        <values>
+                            <string key="composite:composite:list:elementary:string:1" value="example:string:value:1" />
+                            <string key="composite:composite:list:elementary:string:2" value="example:string:value:2" />
+                        </values>
+                    </list>
+                </values>
+            </list>
+        </event>
+    </trace>
+</log>

--- a/tests/xes_composite_att_test.py
+++ b/tests/xes_composite_att_test.py
@@ -1,0 +1,44 @@
+from pm4py.objects.log.importer.xes import importer as xes_importer
+from pm4py.objects.log.exporter.xes import exporter as xes_exporter
+from pm4py.read import read_xes
+from pm4py.write import write_xes
+from tests.constants import (
+    INPUT_DATA_DIR,
+    OUTPUT_DATA_DIR,
+)
+from deepdiff import DeepDiff
+import unittest
+import os
+
+
+class XesCompositeListAttributesTest(unittest.TestCase):
+    def test_minimalXESCompositeListAttributes(self):
+        xes_log_path = os.path.join(INPUT_DATA_DIR, "composite_list_attributes.xes")
+        exported_log_path = os.path.join(
+            OUTPUT_DATA_DIR, "composite_list_attributes.xes"
+        )
+        log = xes_importer.apply(
+            xes_log_path,
+        )
+
+        xes_exporter.apply(log, exported_log_path)
+        log_imported_after_export = xes_importer.apply(exported_log_path)
+
+        self.check_difference(log, log_imported_after_export)
+
+        os.remove(exported_log_path)
+
+    def check_difference(self, log_1, log_2):
+        difference = self.compare_logs(log_1, log_2)
+
+        if difference:
+            self.fail(f"Logs do not match with difference: {difference}")
+
+    def compare_logs(self, log_1, log_2):
+        diff = DeepDiff(log_1, log_2, ignore_order=True)
+        if diff:
+            return diff
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The 'iterparse' read_xes variant failed reading XES event logs, which contained lists consisting of composite attributes (1/ an attribute with meta-attributes or 2/ another list).

This small PR fixes that incosistency. In addition, a minimal XES event log, with both of the aforementioned composite-list-attribute examples, was added to the existing collection of unit tests.