### PR TITLE
[Fix] added support for XES composite list attributes

### DIFF
--- a/pm4py/objects/log/importer/xes/variants/iterparse.py
+++ b/pm4py/objects/log/importer/xes/variants/iterparse.py
@@ -422,10 +422,22 @@ def __parse_attribute(elem, store, key, value, tree):
             store[key] = value
     else:
         if elem.getchildren()[0].tag.endswith(xes_constants.TAG_VALUES):
-            store[key] = {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: list()}
-            tree[elem] = store[key][xes_constants.KEY_CHILDREN]
-            tree[elem.getchildren()[0]] = tree[elem]
+            if isinstance(store, list):
+                store.append((key, {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: list()}))
+                tree[elem] = store[-1][1][xes_constants.KEY_CHILDREN]
+                tree[elem.getchildren()[0]] = tree[elem]
+            else:
+                store[key] = {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: list()}
+                tree[elem] = store[key][xes_constants.KEY_CHILDREN]
+                tree[elem.getchildren()[0]] = tree[elem]
+
         else:
-            store[key] = {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: dict()}
-            tree[elem] = store[key][xes_constants.KEY_CHILDREN]
+            composite_att = {xes_constants.KEY_VALUE: value, xes_constants.KEY_CHILDREN: dict()}
+            if isinstance(store, list):
+                store.append((key, composite_att))
+                tree[elem] = store[-1][1][xes_constants.KEY_CHILDREN]
+            else:
+                store[key] = composite_att
+                tree[elem] = store[key][xes_constants.KEY_CHILDREN]
+
     return tree

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytz
 scipy
 stringdist
 tqdm
+deepdiff

--- a/tests/execute_tests.py
+++ b/tests/execute_tests.py
@@ -21,7 +21,7 @@ enabled_tests = ["SimplifiedInterfaceTest", "SimplifiedInterface2Test", "DocTest
                  "DiagnDfConfChecking", "ProcessModelEvaluationTests", "DecisionTreeTest", "GraphsForming",
                  "HeuMinerTest", "MainFactoriesTest", "AlgorithmTest", "LogFilteringTest",
                  "DataframePrefilteringTest", "StatisticsLogTest", "StatisticsDfTest", "TransitionSystemTest",
-                 "ImpExpFromString", "WoflanTest", "OcelFilteringTest", "OcelDiscoveryTest", "LlmTest"]
+                 "ImpExpFromString", "WoflanTest", "OcelFilteringTest", "OcelDiscoveryTest", "LlmTest", "XesCompositeAttTest"]
 
 loader = unittest.TestLoader()
 suite = unittest.TestSuite()
@@ -201,6 +201,10 @@ if "LlmTest" in enabled_tests:
 
     suite.addTests(loader.loadTestsFromTestCase(LlmTest))
 
+if "XesCompositeAttTest" in enabled_tests:
+    from tests.xes_composite_att_test import XesCompositeListAttributesTest
+
+    suite.addTests(loader.loadTestsFromTestCase(XesCompositeListAttributesTest))
 
 def main():
     runner = unittest.TextTestRunner()

--- a/tests/input_data/composite_list_attributes.xes
+++ b/tests/input_data/composite_list_attributes.xes
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<log xes.version="1849-2016" xes.features="nested-attributes" xmlns="http://www.xes-standard.org/">
+    <string key="Description" value="Minimal XES composite list attributes log."/>
+    <trace>
+        <event>
+            <list key="composite:list" >
+                <values>
+                    <string key="composite:list:elementary:string:1" value="example:string:value:1" />
+                    <string key="" value="">
+                        <string key="composite:string" value="composite:string:value:1" />
+                    </string>
+                    <string key="composite:list:elementary:string:2" value="example:string:value:2" />
+                    <list key="composite:composite:list">
+                        <values>
+                            <string key="composite:composite:list:elementary:string:1" value="example:string:value:1" />
+                            <string key="composite:composite:list:elementary:string:2" value="example:string:value:2" />
+                        </values>
+                    </list>
+                </values>
+            </list>
+        </event>
+    </trace>
+</log>

--- a/tests/xes_composite_att_test.py
+++ b/tests/xes_composite_att_test.py
@@ -1,0 +1,42 @@
+from pm4py.objects.log.importer.xes import importer as xes_importer
+from pm4py.objects.log.exporter.xes import exporter as xes_exporter
+from tests.constants import (
+    INPUT_DATA_DIR,
+    OUTPUT_DATA_DIR,
+)
+from deepdiff import DeepDiff
+import unittest
+import os
+
+
+class XesCompositeListAttributesTest(unittest.TestCase):
+    def test_minimalXESCompositeListAttributes(self):
+        xes_log_path = os.path.join(INPUT_DATA_DIR, "composite_list_attributes.xes")
+        exported_log_path = os.path.join(
+            OUTPUT_DATA_DIR, "composite_list_attributes.xes"
+        )
+        log = xes_importer.apply(
+            xes_log_path,
+        )
+
+        xes_exporter.apply(log, exported_log_path)
+        log_imported_after_export = xes_importer.apply(exported_log_path)
+
+        self.check_difference(log, log_imported_after_export)
+
+        os.remove(exported_log_path)
+
+    def check_difference(self, log_1, log_2):
+        difference = self.compare_logs(log_1, log_2)
+
+        if difference:
+            self.fail(f"Logs do not match with difference: {difference}")
+
+    def compare_logs(self, log_1, log_2):
+        diff = DeepDiff(log_1, log_2, ignore_order=True)
+        if diff:
+            return diff
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Problem**: The XES importer would throw an exception when encountering list attributes containing nested composite attributes (meta-attributes or other list attributes)

**Solution**: Added missing parsing cases to the `__parse_attribute` function in the XES importer

**Additions**: 
- a minimal failing event log demonstrating the previous error behaviour
- the `XesCompositeAttTest` test case was added to the existing test suites

**Impact**: this PR lays the groundwork for extending supported event log formats within the PM4Py library