### PR TITLE
Stochastic playout fix

### DIFF
--- a/pm4py/algo/simulation/playout/petri_net/variants/stochastic_playout.py
+++ b/pm4py/algo/simulation/playout/petri_net/variants/stochastic_playout.py
@@ -38,7 +38,7 @@ class Parameters(Enum):
     NO_TRACES = "noTraces"
     MAX_TRACE_LENGTH = "maxTraceLength"
     LOG = "log"
-    STOCHASTIC_MAP = "stochastic_map"
+    STOCHASTIC_MAP = "smap"
     PETRI_SEMANTICS = "petri_semantics"
 
 

--- a/pm4py/objects/petri_net/utils/performance_map.py
+++ b/pm4py/objects/petri_net/utils/performance_map.py
@@ -186,6 +186,9 @@ def single_element_statistics(log, net, initial_marking, aligned_traces, variant
     if parameters is None:
         parameters = {}
 
+    from pm4py.objects.conversion.log import converter as log_converter
+    log = log_converter.apply(log, variant=log_converter.Variants.TO_EVENT_LOG)
+
     business_hours = parameters["business_hours"] if "business_hours" in parameters else False
     business_hours_slots = parameters["business_hour_slots"] if "business_hour_slots" in parameters else constants.DEFAULT_BUSINESS_HOUR_SLOTS
     count_once_per_trace = parameters["count_once_per_trace"] if "count_once_per_trace" in parameters else False


### PR DESCRIPTION
Hello, thank you for making this wonderful library!
I was trying to do the stochastic playout based off a smap, but ran into two issues:

1. `pm4py/algo/simulation/playout/petri_net/variants/stochastic_playout.py` the STOCHASTIC_MAP param unrolls to "stochastic_map", but the parameter expected by sim.play_out() is 'smap' and thus any stochastic map passed to play_out gets lost. This should be fixed by [the first commit](https://github.com/pm4py/pm4py-core/commit/4bfe3e2935fcb9d16975d7b2966199b332b4053d)
2. `pm4py/objects/petri_net/utils/performance_map.py` expects a legacy log, but does not enforce or check this anywhere, so I added a conversion with [the second commit](https://github.com/pm4py/pm4py-core/commit/7ce09eb38fe2597459f142dce4295c558f0f514c)

Thank you for considering these changes - I wasn't able to select a branch other than release, let me know if I should do anything else.