### PR TITLE
bugfix in human_readable_stat when timedelta is a string with a number smaller than 1 

### DIFF
--- a/pm4py/util/vis_utils.py
+++ b/pm4py/util/vis_utils.py
@@ -62,11 +62,11 @@ def human_readable_stat(timedelta, stat_locale: Optional[Dict[str, str]] = None)
     elif seconds > 0:
         return str(seconds) + stat_locale.get("second", "s")
     else:
-        c = int(float(timedelta*1000))
+        c = int(float(timedelta) * 1000)
         if c > 0:
             return str(c) + stat_locale.get("millisecond", "ms")
         else:
-            return str(int(float(timedelta * 10**9))) + stat_locale.get("nanosecond", "ns")
+            return str(int(float(timedelta) * 10**9)) + stat_locale.get("nanosecond", "ns")
 
 
 def get_arc_penwidth(arc_measure, min_arc_measure, max_arc_measure):


### PR DESCRIPTION
I recently encountered a bug when creating a performance visualization of a heuristics net containing transitions that were smaller than 1 second.

The code for creating the visual loops over all edges to create the labels for the visualization.
In this loop the performance metric is first converted to a string and subsequently passed to the `human_readable_stat` function to create the nicely formatted text.
See `visualization/heuristics_net/variants/pydotplus_vis.py` lines 193 and 215.

The utility function was changed last year to include support for millisecond and nanosecond annotations and I believe this introduced this small bug. The multiplication for ms and ns annotations is done before the conversion to float. 
Reordering of these fixes the bug.

The following code can be used to reproduce the bug in the current release (version 2.7.12):
```
from pm4py.util.vis_utils import human_readable_stat

print(human_readable_stat(1.2))
print(human_readable_stat('1.2'))
print(human_readable_stat(0.2))
print(human_readable_stat('0.2'))
```

The last line will raise a ValueError in the current release and is fixed in this pull request.