### PR TITLE
etc precision bug fix

### DIFF
--- a/pm4py/algo/evaluation/precision/variants/etconformance_token.py
+++ b/pm4py/algo/evaluation/precision/variants/etconformance_token.py
@@ -117,8 +117,8 @@ def apply(log: EventLog, net: PetriNet, marking: Marking, final_marking: Marking
     start_activities = set(get_start_activities(log, parameters=parameters))
     trans_en_ini_marking = set([x.label for x in get_visible_transitions_eventually_enabled_by_marking(net, marking)])
     diff = trans_en_ini_marking.difference(start_activities)
-    sum_at += len(log) * len(trans_en_ini_marking)
-    sum_ee += len(log) * len(diff)
+    sum_at += len(log[case_id_key].unique()) * len(trans_en_ini_marking)
+    sum_ee += len(log[case_id_key].unique()) * len(diff)
     # end fix
 
     for i in range(len(aligned_traces)):


### PR DESCRIPTION
Currently the number escaping edges and allowed transitions is just multiplied with `len(log)` which is the length of the `log` object and always equal to 20. We want to multiply with the number of cases in the log.