### PR TITLE
Minor Fix: Equation Formatting in Documentation

### DIFF
--- a/docs/06_conformance_checking.md
+++ b/docs/06_conformance_checking.md
@@ -6,13 +6,13 @@ Conformance checking is a technique to compare a process model with an event log
 
 Token-based replay matches a trace and a Petri net model, starting from the initial place, in order to discover which transitions are executed and in which places we have remaining or missing tokens for the given process instance. Token-based replay is useful for conformance checking: indeed, a trace fits the model if, during its execution, the transitions can be fired without the need to insert any missing tokens. If reaching the final marking is imposed, then a trace fits if it reaches the final marking without any missing or remaining tokens. See explanation.
 
-For each trace, there are four values that have to be determined: produced tokens, remaining tokens, missing tokens, and consumed tokens. Based on that, a formula can be derived, whereby a Petri net (n) and a trace (t) are given as input:
+For each trace, there are four values that have to be determined: produced tokens, remaining tokens, missing tokens, and consumed tokens. Based on that, a formula can be derived, whereby a Petri net ($n$) and a trace ($t$) are given as input:
 
-\[
+$$
 \text{fitness}(n, t) = \frac{1}{2} \left(1 - \frac{r}{p}\right) + \frac{1}{2} \left(1 - \frac{m}{c}\right)
-\]
+$$
 
-To apply the formula to the whole event log, \( p \), \( r \), \( m \), and \( c \) are calculated for each trace, summed up, and finally placed into the formula above.
+To apply the formula to the whole event log, $p$, $r$, $m$, and $c$ are calculated for each trace, summed up, and finally placed into the formula above.
 
 In PM4Py, there is an implementation of a token replayer that can traverse hidden transitions (calculating the shortest paths between places) and can be used with any Petri net model with unique visible transitions and hidden transitions. When a visible transition needs to be fired and not all places in the preset are provided with the correct number of tokens, starting from the current marking, it is checked if there is a sequence of hidden transitions that could be fired to enable the visible transition. The hidden transitions are then fired, and a marking that permits enabling the visible transition is reached.
 

--- a/docs/10_log-model_evaluation.md
+++ b/docs/10_log-model_evaluation.md
@@ -72,9 +72,9 @@ Buijs, Joos CAM, Boudewijn F. van Dongen, and Wil MP van der Aalst. "Quality dim
 
 Basically, a model is considered general if the elements of the model are visited frequently enough during a replay operation (of the log on the model). A model may perfectly fit the log and be perfectly precise (for example, reporting the traces of the log as sequential models going from the initial marking to the final marking; a choice is operated at the initial marking). Hence, to measure generalization, a token-based replay operation is performed, and generalization is calculated as
 
-\[ 1 - \text{avg}_t (\sqrt{1.0 / \text{freq}(t)}) \]
+$$ 1 - \text{avg}_t (\sqrt{1.0 / \text{freq}(t)}) $$
 
-where \(\text{avg}_t\) is the average of the inner value over all the transitions, \(\sqrt{}\) is the square root, and \(\text{freq}(t)\) is the frequency of \(t\) after the replay.
+where $\text{avg}_t$ is the average of the inner value over all the transitions, $\sqrt{}$ is the square root, and $\text{freq}(t)$ is the frequency of $t$ after the replay.
 
 To calculate the generalization between an event log and a Petri net model using the generalization method proposed in this section, use the code on the right side. The resulting value is a number between `0` and `1`.
 
@@ -90,9 +90,9 @@ if __name__ == "__main__":
 Simplicity is the fourth dimension to analyze a process model. In this case, we define simplicity by considering only the Petri net model. The criterion we use for simplicity is the inverse arc degree, as described in the following research paper:
 Blum, Fabian Rojas. "Metrics in process discovery." Technical Report TR/DCC-2015-6, Computer Science Department, University of Chile, 2015.
 
-First, we consider the average degree for a place/transition of the Petri net, defined as the sum of the number of input arcs and output arcs. If all the places have at least one input arc and one output arc, the number is at least 2. Choosing a number \(k\) between 0 and infinity, simplicity based on the inverse arc degree is defined as
+First, we consider the average degree for a place/transition of the Petri net, defined as the sum of the number of input arcs and output arcs. If all the places have at least one input arc and one output arc, the number is at least 2. Choosing a number $k$ between 0 and infinity, simplicity based on the inverse arc degree is defined as
 
-\[ 1.0 / (1.0 + \max(\text{mean\_degree} - k, 0)) \]
+$$ 1.0 / (1.0 + \max(\mathrm{mean\_deg} - k, 0)) $$
 
 To calculate the simplicity of a Petri net model using the inverse arc degree, use the following code. The resulting value is a number between `0` and `1`.
 
@@ -144,7 +144,7 @@ from pm4py.algo.simulation.playout.petri_net import algorithm as simulator
 
 if __name__ == "__main__":
     playout_log = simulator.apply(
-        net, im, fm, 
+        net, im, fm,
         parameters={simulator.Variants.STOCHASTIC_PLAYOUT.value.Parameters.LOG: log},
         variant=simulator.Variants.STOCHASTIC_PLAYOUT
     )


### PR DESCRIPTION
**Problem:**
The equations in two files in the documentation do not render as LaTeX. This issue appears to stem from how GitHub markdown processes LaTeX equations (see [[1]](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions)).

**Solution:**
I replaced the `\( \)` with `$ $` and the `\[ \]` with `$$ $$` as suggested in [1].

I encountered a minor issue in the `docs/10_log-model_evaluation.md` file: 
It appears that GitHub's markdown LaTeX does not accept `\_` within a `\text{}` macro. No matter how I tried, it would not render correctly on GitHub. I researched potential solutions but found nothing more effective (see [[2]](https://github.com/mathjax/MathJax/issues/1770)). I decided to rename it to `\mathrm{mean\_deg}`, which renders in a way that is clear on GitHub.

Additionally, my editor accidentally removed a small trailing whitespace.