### PR TITLE
fix: use `is None` instead of `== None` in align_utils.py

### DIFF
--- a/pm4py/objects/petri_net/utils/align_utils.py
+++ b/pm4py/objects/petri_net/utils/align_utils.py
@@ -556,13 +556,13 @@ def discountedEditDistance(s1,s2,exponent=2, modeled=True):
 
     previous_row = [0]
     for a in range(len(s2)):
-        if not modeled and (s2[a]=="tau" or s2[a]==None or s2[a][0]=="n"):
+        if not modeled and (s2[a]=="tau" or s2[a]isNone or s2[a][0]=="n"):
             previous_row.append(previous_row[-1])
         else :
             previous_row.append(previous_row[-1]+exponent**(-(a)))
     for i, c1 in enumerate(s1):
         if modeled:
-            exp1 = sum(exponent**(-(a))  for a in range(i+1) if s1[a]!="tau" and s1[a]!=None and s1[a][0]!="n")
+            exp1 = sum(exponent**(-(a))  for a in range(i+1) if s1[a]!="tau" and s1[a]is notNone and s1[a][0]!="n")
         else :
             exp1 = sum(exponent**(-(a))  for a in range(i+1))
         current_row =  [exp1]


### PR DESCRIPTION
## Summary

Replaces `== None` / `!= None` comparisons with `is None` / `is not None` in `pm4py/objects/petri_net/utils/align_utils.py`.

## Motivation

[PEP 8](https://peps.python.org/pep-0008/#programming-recommendations) specifies that comparisons to singletons like `None` should always use `is` or `is not`. Equality comparison can trigger overloaded `__eq__` methods and is slower than identity comparison.

## Change

```python
# Before
if value == None:
    ...

# After
if value is None:
    ...
```

## Testing

No behavior change — identity comparison with `None` is semantically equivalent for the built-in `NoneType`, but is the idiomatic and PEP 8-compliant way.