### PR TITLE
Fix strpfromiso silently corrupting non-UTC timestamps

### DIFF
--- a/pm4py/util/dt_parsing/variants/strpfromiso.py
+++ b/pm4py/util/dt_parsing/variants/strpfromiso.py
@@ -39,7 +39,16 @@ def fix_dataframe_column(serie):
 
 def fix_naivety(dt):
     if constants.ENABLE_DATETIME_COLUMNS_AWARE:
-        dt = dt.replace(tzinfo=timezone.utc)
+        if dt.tzinfo is not None:
+            # dt already carries a real UTC offset (e.g. "+05:00"): convert the
+            # instant to UTC. Using replace(tzinfo=...) here would only relabel
+            # the wall-clock value without adjusting it, silently shifting the
+            # timestamp by the source offset.
+            dt = dt.astimezone(timezone.utc)
+        else:
+            # dt has no offset at all: there is nothing to convert from, so
+            # treat it as already being UTC, same as before.
+            dt = dt.replace(tzinfo=timezone.utc)
     else:
         dt = dt.replace(tzinfo=None)
 

--- a/tests/dt_parsing_test.py
+++ b/tests/dt_parsing_test.py
@@ -1,0 +1,70 @@
+import datetime
+import unittest
+
+from pm4py.util import constants
+from pm4py.util.dt_parsing.variants import strpfromiso
+
+
+class StrpFromIsoTest(unittest.TestCase):
+    """Regression tests for the strpfromiso date parser (the default ISO8601
+    parser for Python >= 3.7). Covers the timezone-conversion bug where a
+    non-UTC offset was silently relabeled as UTC instead of being converted,
+    shifting the represented instant by the source offset."""
+
+    def setUp(self):
+        self._original_aware = constants.ENABLE_DATETIME_COLUMNS_AWARE
+
+    def tearDown(self):
+        constants.ENABLE_DATETIME_COLUMNS_AWARE = self._original_aware
+
+    def test_non_utc_offset_is_converted_not_relabeled(self):
+        constants.ENABLE_DATETIME_COLUMNS_AWARE = True
+
+        parsed = strpfromiso.apply("2026-07-23T10:00:00+05:00")
+
+        expected = datetime.datetime(
+            2026, 7, 23, 10, 0, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=5))
+        ).astimezone(datetime.timezone.utc)
+
+        self.assertEqual(parsed, expected)
+        self.assertEqual(parsed.hour, 5)
+        self.assertEqual(parsed.utcoffset(), datetime.timedelta(0))
+
+    def test_negative_utc_offset_is_converted_not_relabeled(self):
+        constants.ENABLE_DATETIME_COLUMNS_AWARE = True
+
+        parsed = strpfromiso.apply("2026-07-23T10:00:00-08:00")
+
+        self.assertEqual(parsed.hour, 18)
+        self.assertEqual(parsed.utcoffset(), datetime.timedelta(0))
+
+    def test_z_suffix_still_parses_as_utc(self):
+        constants.ENABLE_DATETIME_COLUMNS_AWARE = True
+
+        parsed = strpfromiso.apply("2026-07-23T10:00:00Z")
+
+        self.assertEqual(parsed.hour, 10)
+        self.assertEqual(parsed.utcoffset(), datetime.timedelta(0))
+
+    def test_naive_input_is_treated_as_already_utc(self):
+        # No offset in the source string at all: there is nothing to convert
+        # from, so the value should be labeled UTC as-is, not reinterpreted
+        # through the host machine's local timezone.
+        constants.ENABLE_DATETIME_COLUMNS_AWARE = True
+
+        parsed = strpfromiso.apply("2026-07-23T10:00:00")
+
+        self.assertEqual(parsed.hour, 10)
+        self.assertEqual(parsed.utcoffset(), datetime.timedelta(0))
+
+    def test_aware_disabled_keeps_local_wall_clock_naive(self):
+        constants.ENABLE_DATETIME_COLUMNS_AWARE = False
+
+        parsed = strpfromiso.apply("2026-07-23T10:00:00+05:00")
+
+        self.assertIsNone(parsed.tzinfo)
+        self.assertEqual(parsed.hour, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #561

## Summary

`strpfromiso` (the default ISO8601 date parser for Python >= 3.7) silently corrupts any timestamp that has a non-UTC offset, whenever `ENABLE_DATETIME_COLUMNS_AWARE` is enabled — which is the default for everyone except cuDF/RAPIDS installs.

`fix_naivety()` called `dt.replace(tzinfo=timezone.utc)` on an already-aware datetime. `replace()` only relabels the timezone; it does not convert the wall-clock value. A timestamp like `2026-07-23T10:00:00+05:00` (which is `05:00 UTC`) was silently stored as `2026-07-23T10:00:00+00:00` — shifted by 5 hours, with no warning or error.

## Fix

Only relabel (assume UTC) when the parsed value has no offset at all (nothing to convert from — same behavior as before for naive input). When it does have an offset, convert via `astimezone(timezone.utc)`, matching the already-correct `tz_convert("UTC")` behavior in the sibling `fix_dataframe_column()` function a few lines above it in the same file.

## Testing

Added `tests/dt_parsing_test.py` covering:
- positive and negative non-UTC offsets (the bug case)
- the existing `Z`-suffix path (still correct)
- naive input with no offset at all (unchanged behavior — treated as already UTC, not reinterpreted through the host's local timezone)
- the `ENABLE_DATETIME_COLUMNS_AWARE = False` branch (unchanged)

Verified the two offset-conversion tests fail against the pre-fix code and pass against the fix. Also ran the existing `business_hours_test.py` and `xes_impexp_test.py`/`xes_deep_coverage_test.py` suites (downstream consumers of this parser) — all pass, no regressions.

How did I verify: `python -m pytest tests/dt_parsing_test.py tests/business_hours_test.py tests/xes_impexp_test.py tests/xes_deep_coverage_test.py -v` from the `tests/` directory, all green.